### PR TITLE
Add a "filter" to "/ExchangeSteps.ListExchangeSteps" gRPC method.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -29,6 +29,10 @@ service ExchangeSteps {
   rpc GetExchangeStep(GetExchangeStepRequest) returns (ExchangeStep);
 
   // Lists `ExchangeSteps`.
+  //
+  // This method is critical to the core "flow" of the system: clients will call
+  // "/ExchangeSteps.ListExchangeSteps" with a filter for the NOT_STARTED state
+  // and then create new `ExchangeStepAttempts` for those.
   rpc ListExchangeSteps(ListExchangeStepsRequest)
       returns (ListExchangeStepsResponse);
 }
@@ -41,7 +45,10 @@ message GetExchangeStepRequest {
 
 // Request message for `ListExchangeSteps` method.
 message ListExchangeStepsRequest {
-  // The Exchange that the ExchangeSteps belong to. Required.
+  // The Exchange that the ExchangeSteps belong to.
+  //
+  // Optional: if not provided, this will list ExchangeSteps from all Exchanges
+  // that the caller has access to.
   Exchange.Key parent = 1;
 
   // The maximum number of `ExchangeStep`s to return.
@@ -60,6 +67,13 @@ message ListExchangeStepsRequest {
   // `ListExchangeStepsRequest` must match the call that provided the page
   // token.
   string page_token = 3;
+
+  // Filter for results. The API will return ExchangeSteps that match ALL of the
+  // given conditions. Repeated fields are treated as disjunctions.
+  message Filter {
+    repeated ExchangeStep.State states = 1;
+  }
+  Filter filter = 4;
 }
 
 // Response message for `ListExchangeSteps` method.


### PR DESCRIPTION
This also specifies that the Key is optional to allow searching across
multiple Exchanges at once.

These changes enable API clients to efficiently find work that needs to
be done (in other words, ExchangeSteps in the NOT_STARTED state).

world-federation-of-advertisers/cross-media-measurement#3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/7)
<!-- Reviewable:end -->
