### PR TITLE
Refactor handling of ExchangeStep inputs/outputs.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -45,9 +45,13 @@ message ExchangeStep {
   // here are the values of that map.
   map<string, SharedData> inputs = 4;
 
-  // Output-only. If ExchangeStep has a `state` of `SUCCEEDED`, it will contain
-  // an entry for each `step.output_labels` entry available to the other party.
-  // The keys here are the values of that map.
+  // Output-only. This will be populated only if `state` is `SUCCEEDED`.
+  // The keys of `outputs` are the subset of values of `step.output_labels`
+  // that are also values of `input_labels` of some `ExchangeWorkflow.Step` to
+  // be executed by the other party.
+  //
+  // Intuitively, these are the output labels that that other party needs to
+  // access.
   map<string, SharedData> outputs = 5;
 
   enum State {
@@ -84,6 +88,8 @@ message ExchangeStep {
         string https_uri = 2;
 
         // Represents a query to execute under Google Cloud's BigQuery.
+        // The exact details are TBD but this may end up being the name of an
+        // AuthorizedView from which all rows should be read.
         string google_big_query = 3;
 
         // Represents a file accessible via Google Cloud Storage. While
@@ -94,6 +100,8 @@ message ExchangeStep {
 
         // Represents a file accessible via AWS S3. While sometimes HTTPS can be
         // used directly, some may prefer to use ACLs rather than access tokens.
+        // This should be a standard S3 path of the format
+        // "s3://bucket-name/and/some/path".
         string amazon_s3 = 5;
       }
     }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -76,6 +76,7 @@ message ExchangeStep {
     // `Location` payloads.
     bytes encrypted_signed_location = 1;
 
+    // TODO(@efoxepstein): refactor to use a resource URI or something generic.
     message Location {
       // This should correspond to one of the values in the
       // `ExchangeWorkflow.Step.output_labels` map for a step.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -83,8 +83,8 @@ message ExchangeStep {
         // with access tokens in here.
         string https_uri = 2;
 
-        // Represents a query to execute under BigQuery.
-        string big_query = 3;
+        // Represents a query to execute under Google Cloud's BigQuery.
+        string google_big_query = 3;
 
         // Represents a file accessible via Google Cloud Storage. While
         // sometime HTTPS can be used directly, some may prefer to use ACLs

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -36,9 +36,19 @@ message ExchangeStep {
   // Output-only.
   State state = 2;
 
-  // Output-only. Denotes the step of the grandparent RecurringExchange's
-  // ExchangeWorkflow that this ExchangeStep corresponds to.
+  // Denotes the step of the grandparent RecurringExchange's ExchangeWorkflow
+  // that this ExchangeStep corresponds to. Output-only.
   ExchangeWorkflow.Step step = 3;
+
+  // Output-only. Once predecessor steps complete, this will contain an entry
+  // for each `step.input_labels` entry produced by the other party. The keys
+  // here are the values of that map.
+  map<string, SharedData> inputs = 4;
+
+  // Output-only. If ExchangeStep has a `state` of `SUCCEEDED`, it will contain
+  // an entry for each `step.output_labels` entry available to the other party.
+  // The keys here are the values of that map.
+  map<string, SharedData> outputs = 5;
 
   enum State {
     STATE_UNSPECIFIED = 0;
@@ -54,5 +64,38 @@ message ExchangeStep {
 
     // The step has permanently failed. Terminal state.
     FAILED = 4;
+  }
+
+  // Represents how to access an output/input.
+  message SharedData {
+    // Encrypted, serialized `SignedData` messages containing serialized
+    // `Location` payloads.
+    bytes encrypted_signed_location = 1;
+
+    message Location {
+      // This should correspond to one of the values in the
+      // `ExchangeWorkflow.Step.output_labels` map for a step.
+      string label = 1;
+
+      oneof location {
+        // Represents a file to download over HTTPS. Since SharedOutput is only
+        // shared via an encrypted SignedData message, it is safe to put URLs
+        // with access tokens in here.
+        string https_uri = 2;
+
+        // Represents a query to execute under BigQuery.
+        string big_query = 3;
+
+        // Represents a file accessible via Google Cloud Storage. While
+        // sometime HTTPS can be used directly, some may prefer to use ACLs
+        // rather than access tokens. This should be a standard GCS path of the
+        // format "gcs://bucket-name/and/some/path".
+        string google_cloud_storage = 4;
+
+        // Represents a file accessible via AWS S3. While sometimes HTTPS can be
+        // used directly, some may prefer to use ACLs rather than access tokens.
+        string amazon_s3 = 5;
+      }
+    }
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
@@ -48,7 +48,7 @@ message ExchangeStepAttempt {
     // Terminal state.
     SUCCEEDED = 3;
 
-    // THe attempt has failed. The step should be retried unless it is in a
+    // The attempt has failed. The step should be retried unless it is in a
     // terminal state.
     FAILED = 4;
   }
@@ -66,38 +66,9 @@ message ExchangeStepAttempt {
   // Warnings, errors, and other messages for debugging purposes. Append-only.
   repeated DebugLog debug_log_entries = 4;
 
-  // Paths, tables, etc. accessible to the other party.
-  // Each of these is an encrypted SignedData. Each SignedData holds a
-  // serialized SharedOutput protocol buffer.
-  repeated bytes shared_outputs = 5;
-
   // When the ExchangeStepAttempt was created. Output-only.
   google.protobuf.Timestamp start_time = 6;
 
   // When the ExchangeStepAttempt was last updated. Output-only.
   google.protobuf.Timestamp update_time = 7;
-
-  message SharedOutput {
-    string label = 1;
-
-    oneof location {
-      // Represents a file to download over HTTPS. Since SharedOutput is only
-      // shared via an encrypted SignedData message, it is safe to put URLs
-      // with access tokens in here.
-      string https_uri = 2;
-
-      // Represents a query to execute under BigQuery.
-      string big_query = 3;
-
-      // Represents a file accessible via Google Cloud Storage. While sometimes
-      // HTTPS can be used directly, some may prefer to use ACLs rather than
-      // access tokens. This should be a standard GCS path of the format
-      // "gcs://bucket-name/and/some/path".
-      string google_cloud_storage = 4;
-
-      // Represents a file accessible via AWS S3. While sometimes HTTPS can be
-      // used directly, some may prefer to use ACLs rather than access tokens.
-      string amazon_s3 = 5;
-    }
-  }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -41,6 +41,9 @@ service ExchangeStepAttempts {
   rpc AppendLogEntry(AppendLogEntryRequest) returns (ExchangeStepAttempt);
 
   // Marks an `ExchangeStepAttempt` as finished (either successfully or not).
+  //
+  // It is an error to have more than one `SUCCEEDED` `ExchangeStepAttempt` for
+  // any given `ExchangeStep`.
   rpc FinishExchangeStepAttempt(FinishExchangeStepAttemptRequest)
       returns (ExchangeStepAttempt);
 }
@@ -112,4 +115,11 @@ message FinishExchangeStepAttemptRequest {
 
   // Final debug log entries to append concurrently with the state transition.
   repeated ExchangeStepAttempt.DebugLog log_entries = 3;
+
+  // Contains an entry for each output accessible to the other party among those
+  // in the ExchangeStep's `step.output_labels` map. The keys here are values
+  // from `output_labels.
+  //
+  // This field will be ignored if the `final_state` is `FAILED`.
+  map<string, ExchangeStep.SharedData> shared_outputs = 4;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -118,7 +118,7 @@ message FinishExchangeStepAttemptRequest {
 
   // Contains an entry for each output accessible to the other party among those
   // in the ExchangeStep's `step.output_labels` map. The keys here are values
-  // from `output_labels.
+  // from `output_labels`.
   //
   // This field will be ignored if the `final_state` is `FAILED`.
   map<string, ExchangeStep.SharedData> shared_outputs = 4;


### PR DESCRIPTION
* Rename SharedOutput to SharedData.
* Add input and output maps to ExchangeStep.
* Remove output data from ExchangeStepAttempt.
* Enable uploading SharedData as part of FinishExchangeStepAttempt.

See world-federation-of-advertisers/cross-media-measurement#3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/12)
<!-- Reviewable:end -->
