### PR TITLE
Move the data_provider_participation_signature field to Requisition.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -32,6 +32,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":crypto_proto",
+        ":data_provider_proto",
         ":duchy_proto",
         ":measurement_consumer_proto",
         ":measurement_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -82,17 +82,6 @@ message Measurement {
     // between `measurement_public_key` in `measurement_spec` and
     // `data_provider_public_key`.
     bytes encrypted_requisition_spec = 4;
-
-    // Cryptographic digital signature of the "requisition fingerprint" which
-    // can be verified using the `DataProvider`'s certificate. Output-only. Only
-    // set if the corresponding `Requisition` has been fulfilled.
-    //
-    // The requisition fingerprint is defined as the concatenation of:
-    // 1. The SHA256 hash of `encrypted_requisition_spec`.
-    // 2. The SHA256 hash of the concatenation of
-    //    `serialized_data_provider_list` and `data_provider_list_salt`.
-    // 3. The `data` in `measurement_spec`.
-    bytes data_provider_participation_signature = 5;
   }
   // The measurement entry for each `DataProvider`. This can be logically
   // represented as a map uniquely keyed by `DataProvider.Key`. Required.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "wfa/measurement/api/v2alpha/crypto.proto";
+import "wfa/measurement/api/v2alpha/data_provider.proto";
 import "wfa/measurement/api/v2alpha/duchy.proto";
 import "wfa/measurement/api/v2alpha/measurement.proto";
 import "wfa/measurement/api/v2alpha/measurement_consumer.proto";
@@ -56,13 +57,17 @@ message Requisition {
   // Immutable.
   ProtocolConfig.Key protocol_config = 5;
 
+  // Denormalized `data_provider_certificate` field from the corresponding
+  // `DataProviderEntry` in `measurement`.  Required. Immutable.
+  DataProviderCertificate.Key data_provider_certificate = 6;
+
   // Denormalized `data_provider_public_key` field from the corresponding
   // `DataProviderEntry` in `measurement`.  Required. Immutable.
-  SignedData data_provider_public_key = 6;
+  SignedData data_provider_public_key = 7;
 
   // Denormalized `encrypted_requisition_spec` field from the corresponding
   // `DataProviderEntry` in `measurement`.  Required. Immutable.
-  bytes encrypted_requisition_spec = 7;
+  bytes encrypted_requisition_spec = 8;
 
   message DuchyEntry {
     // Resource key of the `Duchy` that this entry is for. Required. Immutable.
@@ -78,7 +83,7 @@ message Requisition {
   }
   // The  entry for each `Duchy`. This can be logically represented as a map
   // uniquely keyed by `Duchy.Key`. Required. Immutable.
-  repeated DuchyEntry duchy_entries = 8;
+  repeated DuchyEntry duchy_entries = 9;
 
   // State of a `Requisition`.
   enum State {
@@ -93,7 +98,17 @@ message Requisition {
     UNFULFILLABLE = 3;
   }
   // The state of this `Requisition`.
-  State state = 9;
+  State state = 10;
+
+  // Cryptographic digital signature of the "requisition fingerprint" which
+  // can be verified using the `data_provider_certificate`. Only set if `state`
+  // is `FULFILLED`.
+  //
+  // The requisition fingerprint is defined as the concatenation of:
+  // 1. The SHA256 hash of `encrypted_requisition_spec`.
+  // 2. `data_provider_list_hash` from `encrypted_requisition_spec`.
+  // 3. `data` from `measurement_spec`.
+  bytes data_provider_participation_signature = 11;
 
   message Refusal {
     enum Justification {
@@ -139,6 +154,6 @@ message Requisition {
   }
   // Details on why the requisition is in the `UNFULFILLABLE` state.
   oneof unfulfillable_details {
-    Refusal refusal = 10;
+    Refusal refusal = 12;
   }
 }


### PR DESCRIPTION
This makes the data_provider_entries field of Measurement actually immutable as documented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/17)
<!-- Reviewable:end -->
