### PR TITLE
Add Measurement resource key to ListRequisitions filter criteria.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -111,6 +111,7 @@ proto_library(
     deps = [
         ":data_provider_proto",
         ":measurement_consumer_proto",
+        ":measurement_proto",
         ":requisition_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "wfa/measurement/api/v2alpha/data_provider.proto";
+import "wfa/measurement/api/v2alpha/measurement.proto";
 import "wfa/measurement/api/v2alpha/requisition.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -59,6 +60,7 @@ message ListRequisitionsRequest {
   // fields specified as logical ANDs.
   message Filter {
     repeated Requisition.State states = 1;
+    repeated Measurement.Key measurements = 2;
   }
   // Result filter. If a page token is specified, then this will be ignored and
   // the filter for the first page will be applied.


### PR DESCRIPTION
This allows MeasurementConsumer owners to list Requisitions for a given set of Measurements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/18)
<!-- Reviewable:end -->
