### PR TITLE
Drop free-form tags map from Measurement in favor of reference ID.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -143,9 +143,11 @@ message Measurement {
   // `result_public_key`.
   bytes encrypted_result = 11;
 
-  // Map of caller-defined tag keys to values for this `Measurement`.
-  // These are to enable `MeasurementConsumer`s to apply labels to the
-  // `Measurement` to aid in filtering and identifying later on.
-  // Do not put sensitive data in this field.
-  map<string, string> tags = 12;
+  // ID referencing the `Measurement` in an external system, provided by the
+  // Measurement Consumer.
+  //
+  // If set, this value must be unique among `Measurement`s for the parent
+  // `MeasurementConsumer`. This serves as an idempotency key for the
+  // `Measurement`.
+  string measurement_reference_id = 12;
 }


### PR DESCRIPTION
This provides a simpler idompotency mechanism for Measurement Consumers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/19)
<!-- Reviewable:end -->
