### PR TITLE
Refactor ExchangeStep and ExchangeStepsService.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -258,8 +258,9 @@ proto_library(
     name = "exchange_steps_service_proto",
     srcs = ["exchange_steps_service.proto"],
     deps = [
-        ":exchange_proto",
+        ":data_provider_proto",
         ":exchange_step_proto",
+        ":model_provider_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -60,21 +60,26 @@ message ExchangeStep {
     // Some predecessor ExchangeStep is not in state SUCCEEDED.
     BLOCKED = 1;
 
-    // All predecessor ExchangeSteps are in state `SUCCEEDED` and all associated
-    // ExchangeStepAttempts, if there are any, are in state `FAILED`.
+    // All predecessor ExchangeSteps are in state `SUCCEEDED` and there are no
+    // associated ExchangeStepAttempts.
     READY = 2;
+
+    // All predecessor ExchangeSteps are in state `SUCCEEDED` and there is at
+    // least one associated ExchangeStepAttempt and all associated
+    // ExchangeStepAttempts are in state `FAILED`.
+    READY_FOR_RETRY = 3;
 
     // All predecessor ExchangeSteps are in state `SUCCEEDED` and an associated
     // ExchangeStepAttempt is in state `ACTIVE`.
-    IN_PROGRESS = 3;
+    IN_PROGRESS = 4;
 
     // The step has succeeded. Terminal state. This implies that an associated
     // ExchangeStepAttempt is in state `SUCCEEDED`.
-    SUCCEEDED = 4;
+    SUCCEEDED = 5;
 
     // The step has permanently failed. Terminal state. This implies that an
     // associated ExchangeStepAttempt is in state `FAILED_STEP`.
-    FAILED = 5;
+    FAILED = 6;
   }
 
   // Represents how to access an output/input.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -57,17 +57,25 @@ message ExchangeStep {
   enum State {
     STATE_UNSPECIFIED = 0;
 
-    // There are no ExchangeStepAttempts associated with this ExchangeStep.
-    NOT_STARTED = 1;
+    // Some predecessor ExchangeStep is not in state SUCCEEDED.
+    BLOCKED = 1;
 
-    // The step is currently being processed.
-    IN_PROGRESS = 2;
+    // All predecessor ExchangeSteps are in state SUCCEEDED and all associated
+    // ExchangeStepAttempts, if there are any, are in a FAILED state.
+    READY = 2;
 
-    // The step has succeeded. Terminal state.
-    SUCCEEDED = 3;
+    // All predecessor ExchangeSteps are in state SUCCEEDED and an associated
+    // ExchangeStepAttempt is in an ACTIVE state.
+    IN_PROGRESS = 3;
 
-    // The step has permanently failed. Terminal state.
-    FAILED = 4;
+    // The step has succeeded. Terminal state. This implies that an associated
+    // ExchangeStepAttempt is in a SUCCEEDED state.
+    SUCCEEDED = 4;
+
+    // The step has permanently failed. Terminal state. Note that the presence
+    // of associated ExchangeStepAttempts in a FAILED state does not imply that
+    // the ExchangeStep will be FAILED.
+    FAILED = 5;
   }
 
   // Represents how to access an output/input.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -60,21 +60,21 @@ message ExchangeStep {
     // Some predecessor ExchangeStep is not in state SUCCEEDED.
     BLOCKED = 1;
 
-    // All predecessor ExchangeSteps are in state SUCCEEDED and all associated
-    // ExchangeStepAttempts, if there are any, are in a FAILED state.
+    // All predecessor ExchangeSteps are in state `SUCCEEDED` and all associated
+    // ExchangeStepAttempts, if there are any, are in a `TEMPORARILY_FAILED`
+    // state.
     READY = 2;
 
-    // All predecessor ExchangeSteps are in state SUCCEEDED and an associated
-    // ExchangeStepAttempt is in an ACTIVE state.
+    // All predecessor ExchangeSteps are in state `SUCCEEDED` and an associated
+    // ExchangeStepAttempt is in state `ACTIVE`.
     IN_PROGRESS = 3;
 
     // The step has succeeded. Terminal state. This implies that an associated
-    // ExchangeStepAttempt is in a SUCCEEDED state.
+    // ExchangeStepAttempt is in state `SUCCEEDED`.
     SUCCEEDED = 4;
 
-    // The step has permanently failed. Terminal state. Note that the presence
-    // of associated ExchangeStepAttempts in a FAILED state does not imply that
-    // the ExchangeStep will be FAILED.
+    // The step has permanently failed. Terminal state. This implies that an
+    // associated ExchangeStepAttempt is in state `PERMANENTLY_FAILED`.
     FAILED = 5;
   }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -61,8 +61,7 @@ message ExchangeStep {
     BLOCKED = 1;
 
     // All predecessor ExchangeSteps are in state `SUCCEEDED` and all associated
-    // ExchangeStepAttempts, if there are any, are in a `TEMPORARILY_FAILED`
-    // state.
+    // ExchangeStepAttempts, if there are any, are in state `FAILED`.
     READY = 2;
 
     // All predecessor ExchangeSteps are in state `SUCCEEDED` and an associated
@@ -74,7 +73,7 @@ message ExchangeStep {
     SUCCEEDED = 4;
 
     // The step has permanently failed. Terminal state. This implies that an
-    // associated ExchangeStepAttempt is in state `PERMANENTLY_FAILED`.
+    // associated ExchangeStepAttempt is in state `FAILED_STEP`.
     FAILED = 5;
   }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
@@ -50,11 +50,11 @@ message ExchangeStepAttempt {
 
     // The attempt has failed but the `ExchangeStep` can be retried.
     // Terminal state.
-    TEMPORARILY_FAILED = 4;
+    FAILED = 4;
 
     // The attempt has failed and the `ExchangeStep` should not be retried.
     // Terminal state.
-    PERMANENTLY_FAILED = 5;
+    FAILED_STEP = 5;
   }
 
   // State of the ExchangeStepAttempt. Output-only.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
@@ -48,9 +48,13 @@ message ExchangeStepAttempt {
     // Terminal state.
     SUCCEEDED = 3;
 
-    // The attempt has failed. The step should be retried unless it is in a
-    // terminal state.
-    FAILED = 4;
+    // The attempt has failed but the `ExchangeStep` can be retried.
+    // Terminal state.
+    TEMPORARILY_FAILED = 4;
+
+    // The attempt has failed and the `ExchangeStep` should not be retried.
+    // Terminal state.
+    PERMANENTLY_FAILED = 5;
   }
 
   // State of the ExchangeStepAttempt. Output-only.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -51,8 +51,8 @@ message GetExchangeStepRequest {
 message FindReadyExchangeStepRequest {
   // Required. Only includes steps belonging to this party.
   oneof party {
-    DataProvider.Key data_provider = 3;
-    ModelProvider.Key model_provider = 4;
+    DataProvider.Key data_provider = 1;
+    ModelProvider.Key model_provider = 2;
   }
 }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -16,8 +16,9 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
-import "wfa/measurement/api/v2alpha/exchange.proto";
+import "wfa/measurement/api/v2alpha/data_provider.proto";
 import "wfa/measurement/api/v2alpha/exchange_step.proto";
+import "wfa/measurement/api/v2alpha/model_provider.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -28,13 +29,16 @@ service ExchangeSteps {
   // Returns the `ExchangeStep` with the specified resource key.
   rpc GetExchangeStep(GetExchangeStepRequest) returns (ExchangeStep);
 
-  // Lists `ExchangeSteps`.
+  // Finds ExchangeSteps that are ready to be worked on.
   //
-  // This method is critical to the core "flow" of the system: clients will call
-  // "/ExchangeSteps.ListExchangeSteps" with a filter for the NOT_STARTED state
-  // and then create new `ExchangeStepAttempts` for those.
-  rpc ListExchangeSteps(ListExchangeStepsRequest)
-      returns (ListExchangeStepsResponse);
+  // This is different from a standard List RPC endpoint because (a) it only
+  // includes results in state READY and (b) there are no filters or parent
+  // selection. Instead, the "parent" is either the DataProvider or the
+  // ModelProvider -- the party to execute the step.
+  //
+  // This method is focused on the one known use case of listing ExchangeSteps.
+  rpc ListReadyExchangeSteps(ListReadyExchangeStepsRequest)
+      returns (ListReadyExchangeStepsResponse);
 }
 
 // Request message for `GetExchangeStep` method.
@@ -43,41 +47,31 @@ message GetExchangeStepRequest {
   ExchangeStep.Key key = 1;
 }
 
-// Request message for `ListExchangeSteps` method.
-message ListExchangeStepsRequest {
-  // The Exchange that the ExchangeSteps belong to.
-  //
-  // Optional: if not provided, this will list ExchangeSteps from all Exchanges
-  // that the caller has access to.
-  Exchange.Key parent = 1;
-
+// Request message for `ListReadyExchangeSteps` method.
+message ListReadyExchangeStepsRequest {
   // The maximum number of `ExchangeStep`s to return.
   // The service may return fewer than this value.
   // If unspecified, at most 50 `ExchangeStep`s will be returned.
   // The maximum value is 1000; values above 1000 will be coerced to 1000.
-  //
-  // Since most protocols will have fewer than 50 ExchangeSteps, this can
-  // typically be left unset.
-  int32 page_size = 2;
+  int32 page_size = 1;
 
   // A page token, received from a previous `ListExchangeStepsRequest` call.
   // Provide this to retrieve the subsequent page.
   //
   // When paginating, all other parameters provided to
-  // `ListExchangeStepsRequest` must match the call that provided the page
+  // `ListReadyExchangeStepsRequest` must match the call that provided the page
   // token.
-  string page_token = 3;
+  string page_token = 2;
 
-  // Filter for results. The API will return ExchangeSteps that match ALL of the
-  // given conditions. Repeated fields are treated as disjunctions.
-  message Filter {
-    repeated ExchangeStep.State states = 1;
+  // Required. Only includes steps belonging to this party.
+  oneof party {
+    DataProvider.Key data_provider = 3;
+    ModelProvider.Key model_provider = 4;
   }
-  Filter filter = 4;
 }
 
-// Response message for `ListExchangeSteps` method.
-message ListExchangeStepsResponse {
+// Response message for `ListReadyExchangeSteps` method.
+message ListReadyExchangeStepsResponse {
   // Page of `ExchangeStep`s.
   repeated ExchangeStep exchange_steps = 1;
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -29,16 +29,16 @@ service ExchangeSteps {
   // Returns the `ExchangeStep` with the specified resource key.
   rpc GetExchangeStep(GetExchangeStepRequest) returns (ExchangeStep);
 
-  // Finds ExchangeSteps that are ready to be worked on.
+  // Finds a single ExchangeStep that is ready to be worked on.
   //
-  // This is different from a standard List RPC endpoint because (a) it only
-  // includes results in state READY and (b) there are no filters or parent
-  // selection. Instead, the "parent" is either the DataProvider or the
-  // ModelProvider -- the party to execute the step.
+  // This could be emulated with a single standard List RPC endpoint with
+  // appropriate filters, but that adds unnecessary complexity to the API.
   //
-  // This method is focused on the one known use case of listing ExchangeSteps.
-  rpc ListReadyExchangeSteps(ListReadyExchangeStepsRequest)
-      returns (ListReadyExchangeStepsResponse);
+  // If there are no ready ExchangeSteps, this will return an empty response.
+  // Since this is expected, normal behavior, it does NOT return a NOT_FOUND
+  // error.
+  rpc FindReadyExchangeStep(FindReadyExchangeStepRequest)
+      returns (FindReadyExchangeStepResponse);
 }
 
 // Request message for `GetExchangeStep` method.
@@ -47,22 +47,8 @@ message GetExchangeStepRequest {
   ExchangeStep.Key key = 1;
 }
 
-// Request message for `ListReadyExchangeSteps` method.
-message ListReadyExchangeStepsRequest {
-  // The maximum number of `ExchangeStep`s to return.
-  // The service may return fewer than this value.
-  // If unspecified, at most 50 `ExchangeStep`s will be returned.
-  // The maximum value is 1000; values above 1000 will be coerced to 1000.
-  int32 page_size = 1;
-
-  // A page token, received from a previous `ListExchangeStepsRequest` call.
-  // Provide this to retrieve the subsequent page.
-  //
-  // When paginating, all other parameters provided to
-  // `ListReadyExchangeStepsRequest` must match the call that provided the page
-  // token.
-  string page_token = 2;
-
+// Request message for `FindReadyExchangeStep` method.
+message FindReadyExchangeStepRequest {
   // Required. Only includes steps belonging to this party.
   oneof party {
     DataProvider.Key data_provider = 3;
@@ -70,12 +56,8 @@ message ListReadyExchangeStepsRequest {
   }
 }
 
-// Response message for `ListReadyExchangeSteps` method.
-message ListReadyExchangeStepsResponse {
-  // Page of `ExchangeStep`s.
-  repeated ExchangeStep exchange_steps = 1;
-
-  // A token, which can be sent as `page_token` to retrieve the next page.
-  // If this field is omitted, there are no subsequent pages.
-  string next_page_token = 2;
+// Response message for `FindReadyExchangeStep` method.
+message FindReadyExchangeStepResponse {
+  // If unset, there was no ready `ExchangeStep`.
+  ExchangeStep exchange_step = 1;
 }


### PR DESCRIPTION
1. Updates ExchangeStep states to be more expressive.

2. Removes ListExchangeSteps and adds ListReadyExchangeSteps. This is a
more focused method to handle our only use case for Listing. We can
always add a generic List later, but this will be easier to implement
and makes the intent very clear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/21)
<!-- Reviewable:end -->
