### PR TITLE
Rename `UNFULFILLABLE` Requisition State to `REFUSED`.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -93,9 +93,10 @@ message Requisition {
     UNFULFILLED = 1;
     // The `Requisition` has been fulfilled. Terminal state.
     FULFILLED = 2;
-    // The `Requisition` cannot be fulfilled. Terminal state. Any `Measurement`s
-    // using this `Requisition` will be put into the `FAILED` state.
-    UNFULFILLABLE = 3;
+    // The `Requisition` has been refused by the `DataProvider`. Terminal state.
+    //
+    // `measurement` will be in the `FAILED` state.
+    REFUSED = 3;
   }
   // The state of this `Requisition`.
   State state = 10;
@@ -152,8 +153,6 @@ message Requisition {
     // Example: "Data Provider X does not support Virtual ID model line Y".
     string message = 2;
   }
-  // Details on why the requisition is in the `UNFULFILLABLE` state.
-  oneof unfulfillable_details {
-    Refusal refusal = 12;
-  }
+  // The refusal that put this `Requisition` into the `REFUSED` state.
+  Refusal refusal = 12;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
@@ -30,10 +30,11 @@ service Requisitions {
   rpc ListRequisitions(ListRequisitionsRequest)
       returns (ListRequisitionsResponse);
 
-  // Marks a `Requisition` as unfulfillable, transitioning it to the
-  // `UNFULFILLABLE` state. This is a terminal state for the `Requisition` and
-  // all computations that rely on the `Requisition` will fail. Consequently,
-  // this should only be used for permanent failures and not transient errors.
+  // Transitions a `Requisition` to the `REFUSED` state.
+  //
+  // This is a terminal state for the `Requisition` and all computations that
+  // rely on the `Requisition` will fail. Consequently, this should only be used
+  // for permanent failures and not transient errors.
   //
   // This is a state transition method (see https://aip.dev/216).
   rpc RefuseRequisition(RefuseRequisitionRequest) returns (Requisition);
@@ -82,6 +83,6 @@ message RefuseRequisitionRequest {
   // Resource key of the `Requisition` to mark as `UNFILLABLE`. Required.
   Requisition.Key key = 1;
 
-  // Details about the refusal.
+  // Details about the refusal. Required.
   Requisition.Refusal refusal = 2;
 }


### PR DESCRIPTION
This more accurately expresses the current use case. Other terminal failure states can be added later if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/22)
<!-- Reviewable:end -->
