### PR TITLE
Drop signature for result public key.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -128,15 +128,13 @@ message Measurement {
   // `SUCCEEDED`.
   bytes aggregator_certificate = 9;
 
-  // Serialized `EncryptionPublicKey` for the `Result`, which can be verified
-  // using `aggregator_certificate`. Output-only.
-  //
-  // Only set if `state` is `SUCCEEDED`.
-  SignedData result_public_key = 10;
+  // Public key for this `Measurement` used to encrypt the result. Output-only.
+  // Must be set if `state` is `SUCCEEDED`.
+  EncryptionPublicKey result_public_key = 10;
 
   // Encrypted `SignedData` containing the serialized `Result`, which can be
-  // verified using `aggregator_certificate`. Output-only. Only set if `state`
-  // is `SUCCEEDED`.
+  // verified using `aggregator_certificate`. Output-only. Must be set if
+  // `state` is `SUCCEEDED`.
   //
   // The symmetric encryption key is derived using a key-agreement protocol
   // between `measurement_public_key` in `measurement_spec` and


### PR DESCRIPTION
The measurement result is signed before being encrypted, so a separate signature is not needed to verify the origin of the key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/24)
<!-- Reviewable:end -->
