### PR TITLE
Replace FindReadyExchangeStep with ClaimReadyExchangeStep.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -261,6 +261,7 @@ proto_library(
     srcs = ["exchange_steps_service.proto"],
     deps = [
         ":data_provider_proto",
+        ":exchange_step_attempt_proto",
         ":exchange_step_proto",
         ":model_provider_proto",
     ],

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -24,13 +24,12 @@ option java_multiple_files = true;
 option java_outer_classname = "ExchangeStepAttemptsServiceProto";
 
 // Service for interacting with `ExchangeStepAttempt` resources.
+//
+// The only way to create an ExchangeStepAttempt is through the
+// /ExchangeSteps.ClaimReadyExchangeStep method.
 service ExchangeStepAttempts {
   // Returns the `ExchangeStepAttempt` with the specified resource key.
   rpc GetExchangeStepAttempt(GetExchangeStepAttemptRequest)
-      returns (ExchangeStepAttempt);
-
-  // Creates a `ExchangeStepAttempt`.
-  rpc CreateExchangeStepAttempt(CreateExchangeStepAttemptRequest)
       returns (ExchangeStepAttempt);
 
   // Lists `ExchangeStepAttempts`.
@@ -52,13 +51,6 @@ service ExchangeStepAttempts {
 message GetExchangeStepAttemptRequest {
   // Resource key.
   ExchangeStepAttempt.Key key = 1;
-}
-
-// Request message for `CreateExchangeStepAttempt` method.
-message CreateExchangeStepAttemptRequest {
-  // The `ExchangeStepAttempt` to create. Required. The `key` field will be
-  // ignored, and the system will assign an ID.
-  ExchangeStepAttempt exchange_step_attempt = 1;
 }
 
 // Request message for `ListExchangeStepAttempts` method.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -62,6 +62,6 @@ message ClaimReadyExchangeStepResponse {
   // The `ExchangeStep`.
   ExchangeStep exchange_step = 1;
 
-  // A new ExchangeStepAttempt for `exchange_step`.
-  ExchangeStepAttempt exchange_step_attempt = 2;
+  // Resource key of a new ExchangeStepAttempt for `exchange_step`.
+  ExchangeStepAttempt.Key exchange_step_attempt = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -18,6 +18,7 @@ package wfa.measurement.api.v2alpha;
 
 import "wfa/measurement/api/v2alpha/data_provider.proto";
 import "wfa/measurement/api/v2alpha/exchange_step.proto";
+import "wfa/measurement/api/v2alpha/exchange_step_attempt.proto";
 import "wfa/measurement/api/v2alpha/model_provider.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -29,16 +30,14 @@ service ExchangeSteps {
   // Returns the `ExchangeStep` with the specified resource key.
   rpc GetExchangeStep(GetExchangeStepRequest) returns (ExchangeStep);
 
-  // Finds a single ExchangeStep that is ready to be worked on.
-  //
-  // This could be emulated with a single standard List RPC endpoint with
-  // appropriate filters, but that adds unnecessary complexity to the API.
+  // Claims a single ExchangeStep that is ready to be worked on and creates an
+  // initial ExchangeStepAttempt for it.
   //
   // If there are no ready ExchangeSteps, this will return an empty response.
   // Since this is expected, normal behavior, it does NOT return a NOT_FOUND
   // error.
-  rpc FindReadyExchangeStep(FindReadyExchangeStepRequest)
-      returns (FindReadyExchangeStepResponse);
+  rpc ClaimReadyExchangeStep(ClaimReadyExchangeStepRequest)
+      returns (ClaimReadyExchangeStepResponse);
 }
 
 // Request message for `GetExchangeStep` method.
@@ -47,17 +46,22 @@ message GetExchangeStepRequest {
   ExchangeStep.Key key = 1;
 }
 
-// Request message for `FindReadyExchangeStep` method.
-message FindReadyExchangeStepRequest {
-  // Required. Only includes steps belonging to this party.
+// Request message for `ClaimReadyExchangeStep` method.
+message ClaimReadyExchangeStepRequest {
+  // If an `ExchangeStep` is returned, it should be executed by this party.
+  // Required.
   oneof party {
     DataProvider.Key data_provider = 1;
     ModelProvider.Key model_provider = 2;
   }
 }
 
-// Response message for `FindReadyExchangeStep` method.
-message FindReadyExchangeStepResponse {
-  // If unset, there was no ready `ExchangeStep`.
+// Response message for `ClaimReadyExchangeStep` method.
+// If there are no ready `ExchangeSteps`, all fields will be unset.
+message ClaimReadyExchangeStepResponse {
+  // The `ExchangeStep`.
   ExchangeStep exchange_step = 1;
+
+  // A new ExchangeStepAttempt for `exchange_step`.
+  ExchangeStepAttempt exchange_step_attempt = 2;
 }


### PR DESCRIPTION
This finds an ExchangeStep in state READY or READY_FOR_RETRY
and then transactionally creates an ExchangeStepAttempt for it.

This will help eliminate race conditions between different workers
trying to claim work in parallel.

See issue world-federation-of-advertisers/cross-media-measurement#3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/26)
<!-- Reviewable:end -->
