### PR TITLE
Support direct output uploading in ExchangeStepAttempts.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -261,6 +261,7 @@ proto_library(
     srcs = ["exchange_steps_service.proto"],
     deps = [
         ":data_provider_proto",
+        ":exchange_step_attempt_proto",
         ":exchange_step_proto",
         ":model_provider_proto",
     ],

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -49,6 +49,13 @@ message ExchangeStep {
   //
   // The values of this map are serialized SignedData. Each SignedData's payload
   // is a byte string of concatenated encrypted values of uniform length.
+  //
+  // When ExchangeStepAttempts are completed successfully,
+  // `/ExchangeStepAttempts.FinishExchangeStepAttempt` is provided
+  // with outputs via its `shared_outputs` field. To populate this field, all of
+  // the shared_outputs are (logically) aggregated into one map, and then
+  // `shared_inputs` is the subset of that map consisting of labels from
+  // `step.input_labels`.
   map<string, bytes> shared_inputs = 4;
 
   enum State {

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -40,19 +40,16 @@ message ExchangeStep {
   // that this ExchangeStep corresponds to. Output-only.
   ExchangeWorkflow.Step step = 3;
 
-  // Output-only. Once predecessor steps complete, this will contain an entry
-  // for each `step.input_labels` entry produced by the other party. The keys
-  // here are the values of that map.
-  map<string, SharedData> inputs = 4;
-
-  // Output-only. This will be populated only if `state` is `SUCCEEDED`.
-  // The keys of `outputs` are the subset of values of `step.output_labels`
-  // that are also values of `input_labels` of some `ExchangeWorkflow.Step` to
-  // be executed by the other party.
+  // Output-only.
   //
-  // Intuitively, these are the output labels that that other party needs to
-  // access.
-  map<string, SharedData> outputs = 5;
+  // Once predecessor steps complete, this will contain an entry for each
+  // `step.input_labels` entry produced by the other party.
+  //
+  // The keys of this map are the values of the `step.input_labels` map.
+  //
+  // The values of this map are serialized SignedData. Each SignedData's payload
+  // is a byte string of concatenated encrypted values of uniform length.
+  map<string, bytes> shared_inputs = 4;
 
   enum State {
     STATE_UNSPECIFIED = 0;
@@ -80,43 +77,5 @@ message ExchangeStep {
     // The step has permanently failed. Terminal state. This implies that an
     // associated ExchangeStepAttempt is in state `FAILED_STEP`.
     FAILED = 6;
-  }
-
-  // Represents how to access an output/input.
-  message SharedData {
-    // Encrypted, serialized `SignedData` messages containing serialized
-    // `Location` payloads.
-    bytes encrypted_signed_location = 1;
-
-    // TODO(@efoxepstein): refactor to use a resource URI or something generic.
-    message Location {
-      // This should correspond to one of the values in the
-      // `ExchangeWorkflow.Step.output_labels` map for a step.
-      string label = 1;
-
-      oneof location {
-        // Represents a file to download over HTTPS. Since SharedOutput is only
-        // shared via an encrypted SignedData message, it is safe to put URLs
-        // with access tokens in here.
-        string https_uri = 2;
-
-        // Represents a query to execute under Google Cloud's BigQuery.
-        // The exact details are TBD but this may end up being the name of an
-        // AuthorizedView from which all rows should be read.
-        string google_big_query = 3;
-
-        // Represents a file accessible via Google Cloud Storage. While
-        // sometime HTTPS can be used directly, some may prefer to use ACLs
-        // rather than access tokens. This should be a standard GCS path of the
-        // format "gcs://bucket-name/and/some/path".
-        string google_cloud_storage = 4;
-
-        // Represents a file accessible via AWS S3. While sometimes HTTPS can be
-        // used directly, some may prefer to use ACLs rather than access tokens.
-        // This should be a standard S3 path of the format
-        // "s3://bucket-name/and/some/path".
-        string amazon_s3 = 5;
-      }
-    }
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -24,13 +24,12 @@ option java_multiple_files = true;
 option java_outer_classname = "ExchangeStepAttemptsServiceProto";
 
 // Service for interacting with `ExchangeStepAttempt` resources.
+//
+// The only way to create an ExchangeStepAttempt is through the
+// /ExchangeSteps.ClaimReadyExchangeStep method.
 service ExchangeStepAttempts {
   // Returns the `ExchangeStepAttempt` with the specified resource key.
   rpc GetExchangeStepAttempt(GetExchangeStepAttemptRequest)
-      returns (ExchangeStepAttempt);
-
-  // Creates a `ExchangeStepAttempt`.
-  rpc CreateExchangeStepAttempt(CreateExchangeStepAttemptRequest)
       returns (ExchangeStepAttempt);
 
   // Lists `ExchangeStepAttempts`.
@@ -52,13 +51,6 @@ service ExchangeStepAttempts {
 message GetExchangeStepAttemptRequest {
   // Resource key.
   ExchangeStepAttempt.Key key = 1;
-}
-
-// Request message for `CreateExchangeStepAttempt` method.
-message CreateExchangeStepAttemptRequest {
-  // The `ExchangeStepAttempt` to create. Required. The `key` field will be
-  // ignored, and the system will assign an ID.
-  ExchangeStepAttempt exchange_step_attempt = 1;
 }
 
 // Request message for `ListExchangeStepAttempts` method.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -116,10 +116,12 @@ message FinishExchangeStepAttemptRequest {
   // Final debug log entries to append concurrently with the state transition.
   repeated ExchangeStepAttempt.DebugLog log_entries = 3;
 
+  // See documentation on `ExchangeStep.shared_inputs`.
+  //
   // Contains an entry for each output accessible to the other party among those
   // in the ExchangeStep's `step.output_labels` map. The keys here are values
   // from `output_labels`.
   //
   // This field will be ignored if the `final_state` is `FAILED`.
-  map<string, ExchangeStep.SharedData> shared_outputs = 4;
+  map<string, bytes> shared_outputs = 4;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -18,6 +18,7 @@ package wfa.measurement.api.v2alpha;
 
 import "wfa/measurement/api/v2alpha/data_provider.proto";
 import "wfa/measurement/api/v2alpha/exchange_step.proto";
+import "wfa/measurement/api/v2alpha/exchange_step_attempt.proto";
 import "wfa/measurement/api/v2alpha/model_provider.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -29,16 +30,14 @@ service ExchangeSteps {
   // Returns the `ExchangeStep` with the specified resource key.
   rpc GetExchangeStep(GetExchangeStepRequest) returns (ExchangeStep);
 
-  // Finds a single ExchangeStep that is ready to be worked on.
-  //
-  // This could be emulated with a single standard List RPC endpoint with
-  // appropriate filters, but that adds unnecessary complexity to the API.
+  // Claims a single ExchangeStep that is ready to be worked on and creates an
+  // initial ExchangeStepAttempt for it.
   //
   // If there are no ready ExchangeSteps, this will return an empty response.
   // Since this is expected, normal behavior, it does NOT return a NOT_FOUND
   // error.
-  rpc FindReadyExchangeStep(FindReadyExchangeStepRequest)
-      returns (FindReadyExchangeStepResponse);
+  rpc ClaimReadyExchangeStep(ClaimReadyExchangeStepRequest)
+      returns (ClaimReadyExchangeStepResponse);
 }
 
 // Request message for `GetExchangeStep` method.
@@ -47,17 +46,22 @@ message GetExchangeStepRequest {
   ExchangeStep.Key key = 1;
 }
 
-// Request message for `FindReadyExchangeStep` method.
-message FindReadyExchangeStepRequest {
-  // Required. Only includes steps belonging to this party.
+// Request message for `ClaimReadyExchangeStep` method.
+message ClaimReadyExchangeStepRequest {
+  // If an `ExchangeStep` is returned, it should be executed by this party.
+  // Required.
   oneof party {
     DataProvider.Key data_provider = 1;
     ModelProvider.Key model_provider = 2;
   }
 }
 
-// Response message for `FindReadyExchangeStep` method.
-message FindReadyExchangeStepResponse {
-  // If unset, there was no ready `ExchangeStep`.
+// Response message for `ClaimReadyExchangeStep` method.
+// If there are no ready `ExchangeSteps`, all fields will be unset.
+message ClaimReadyExchangeStepResponse {
+  // The `ExchangeStep`.
   ExchangeStep exchange_step = 1;
+
+  // Resource key of a new ExchangeStepAttempt for `exchange_step`.
+  ExchangeStepAttempt.Key exchange_step_attempt = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -128,15 +128,13 @@ message Measurement {
   // `SUCCEEDED`.
   bytes aggregator_certificate = 9;
 
-  // Serialized `EncryptionPublicKey` for the `Result`, which can be verified
-  // using `aggregator_certificate`. Output-only.
-  //
-  // Only set if `state` is `SUCCEEDED`.
-  SignedData result_public_key = 10;
+  // Public key for this `Measurement` used to encrypt the result. Output-only.
+  // Must be set if `state` is `SUCCEEDED`.
+  EncryptionPublicKey result_public_key = 10;
 
   // Encrypted `SignedData` containing the serialized `Result`, which can be
-  // verified using `aggregator_certificate`. Output-only. Only set if `state`
-  // is `SUCCEEDED`.
+  // verified using `aggregator_certificate`. Output-only. Must be set if
+  // `state` is `SUCCEEDED`.
   //
   // The symmetric encryption key is derived using a key-agreement protocol
   // between `measurement_public_key` in `measurement_spec` and


### PR DESCRIPTION
* This adds support for a medium-term proposal to use the centralized
APIs to directly store Panel Match outputs.

* While usually uploading large blobs should be via a streaming gRPC,
these blobs are expected to be at most 66 bytes * 15000 = ~1MiB, which
is most efficient to pack into a single gRPC request.

* Streaming support can be added later if it turns out that we
drastically underestimated the size of the payloads.

See issue world-federation-of-advertisers/cross-media-measurement#3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/27)
<!-- Reviewable:end -->
