### PR TITLE
Update exchange shared input/output to support urls

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -51,7 +51,12 @@ message ExchangeStep {
   //
   // The values of this map are signed urls pointing to cloud-hosted SignedData.
   // Each SignedData's payload is a consists of concatenated encrypted values of
-  // uniform length.
+  // uniform length. The urls themselves are signed and encrypted to prevent
+  // a malicious Kingdom operator from having access to the storage.
+  //
+  // In the case where the step's output is expected to be written to remote
+  // storage the urls wil point to a blob containing another signed url, in the
+  // same format described above, for the step's output to be written to.
   //
   // When ExchangeStepAttempts are completed successfully,
   // `/ExchangeStepAttempts.FinishExchangeStepAttempt` is provided
@@ -59,7 +64,7 @@ message ExchangeStep {
   // the shared_outputs are (logically) aggregated into one map, and then
   // `shared_inputs` is the subset of that map consisting of labels from
   // `step.shared_input_labels`.
-  map<string, string> shared_inputs = 5;
+  map<string, bytes> shared_inputs = 5;
 
   enum State {
     STATE_UNSPECIFIED = 0;

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -49,8 +49,9 @@ message ExchangeStep {
   //
   // The keys of this map are the values of the `step.shared_input_labels` map.
   //
-  // The values of this map are serialized SignedData. Each SignedData's payload
-  // is a byte string of concatenated encrypted values of uniform length.
+  // The values of this map are signed urls pointing to cloud-hosted SignedData.
+  // Each SignedData's payload is a consists of concatenated encrypted values of
+  // uniform length.
   //
   // When ExchangeStepAttempts are completed successfully,
   // `/ExchangeStepAttempts.FinishExchangeStepAttempt` is provided
@@ -58,7 +59,7 @@ message ExchangeStep {
   // the shared_outputs are (logically) aggregated into one map, and then
   // `shared_inputs` is the subset of that map consisting of labels from
   // `step.shared_input_labels`.
-  map<string, bytes> shared_inputs = 5;
+  map<string, string> shared_inputs = 5;
 
   enum State {
     STATE_UNSPECIFIED = 0;

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -119,5 +119,5 @@ message FinishExchangeStepAttemptRequest {
   // `shared_output_labels`.
   //
   // This field will be ignored if the `final_state` is `FAILED`.
-  map<string, string> shared_outputs = 4;
+  map<string, bytes> shared_outputs = 4;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -119,5 +119,5 @@ message FinishExchangeStepAttemptRequest {
   // `shared_output_labels`.
   //
   // This field will be ignored if the `final_state` is `FAILED`.
-  map<string, bytes> shared_outputs = 4;
+  map<string, string> shared_outputs = 4;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
@@ -24,7 +24,7 @@ option java_outer_classname = "ExchangeWorkflowProto";
 // the same ExchangeWorkflow.
 //
 // See docs/panelmatch/example-exchange-workflow.textproto for an example
-// ExchangeWorkflow.
+// ExchangeWorkflow.S
 message ExchangeWorkflow {
   // The type of participant that executes each step.
   enum Party {


### PR DESCRIPTION
The size of the blobs exchanged in the api steps is likely to be too
large to reasonably support directly passing via the API. On top of
that, we want to avoid having the Kingdom own the storage for some of
these steps. To avoid issues, this swaps the 'shared' values to string
from blob.

* Only updates the shared input/output map values from blob to string
* Implementation is done in another repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/34)
<!-- Reviewable:end -->
