### PR TITLE
Use ephemeral sender keys for hybrid encryption.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/crypto.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/crypto.proto
@@ -65,6 +65,9 @@ message EncryptionPublicKey {
 
 // Description of a cipher suite for hybrid encryption using the KEM/DEM
 // paradigm.
+//
+// Values encrypted using one of these cipher suites include the sender KEM
+// public key.
 message HybridCipherSuite {
   enum KeyEncapsulationMechanism {
     KEY_ENCAPSULATION_MECHANISM_UNSPECIFIED = 0;

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -81,9 +81,8 @@ message Measurement {
       // this entry, which can be verified using
       // `measurement_consumer_certificate`. Required.
       //
-      // The symmetric encryption key is derived using a key-agreement protocol
-      // between `measurement_public_key` in `measurement_spec` and
-      // `data_provider_public_key`.
+      // The encryption uses the `cipher_suite` specified in `measurement_spec`,
+      // with `data_provider_public_key` as the recipient public key.
       bytes encrypted_requisition_spec = 3;
     }
     // Value of the map entry. Required.
@@ -134,18 +133,13 @@ message Measurement {
   // `SUCCEEDED`.
   bytes aggregator_certificate = 9;
 
-  // Public key for this `Measurement` used to encrypt the result. Output-only.
-  // Must be set if `state` is `SUCCEEDED`.
-  EncryptionPublicKey result_public_key = 10;
-
   // Encrypted `SignedData` containing the serialized `Result`, which can be
   // verified using `aggregator_certificate`. Output-only. Must be set if
   // `state` is `SUCCEEDED`.
   //
-  // The symmetric encryption key is derived using a key-agreement protocol
-  // between `measurement_public_key` in `measurement_spec` and
-  // `result_public_key`.
-  bytes encrypted_result = 11;
+  // The encryption uses the `cipher_suite` specified in `measurement_spec`,
+  // with `measurement_public_key` as the recipient public key.
+  bytes encrypted_result = 10;
 
   // ID referencing the `Measurement` in an external system, provided by the
   // Measurement Consumer.
@@ -153,5 +147,5 @@ message Measurement {
   // If set, this value must be unique among `Measurement`s for the parent
   // `MeasurementConsumer`. This serves as an idempotency key for the
   // `Measurement`.
-  string measurement_reference_id = 12;
+  string measurement_reference_id = 11;
 }


### PR DESCRIPTION
This means that the sender generates a new asymmetric key pair for each message, and throws away the private key after encrypting. The encryption output contains the public key from this pair along with the ciphertext. See https://en.wikipedia.org/wiki/Integrated_Encryption_Scheme.

For Measurements, this is comprised of the following changes:
* The per-Measurement public key that the MC generates is only used as a recipient key, e.g. for encrypting the result.
  * The MC generates a separate ephemeral key pair for each `RequisitionSpec`.
* The `result_public_key field` is no longer needed, since that key is embedded in the encrypted value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/35)
<!-- Reviewable:end -->
