### PR TITLE
Include public key certificate in DataProvider and MeasurementConsumer.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/certificate.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/certificate.proto
@@ -32,6 +32,9 @@ message Certificate {
   };
 
   // Resource name.
+  //
+  // The resource ID alias "preferred" may be used in place of the `Certificate`
+  // ID to refer to the *preferred* `Certificate`.
   string name = 1;
 
   // X.509 certificate in DER format. Required. Immutable.

--- a/src/main/proto/wfa/measurement/api/v2alpha/certificates_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/certificates_service.proto
@@ -25,6 +25,9 @@ option java_outer_classname = "CertificatesServiceProto";
 
 // Service for interacting with `Certificate` resources.
 service Certificates {
+  // Returns the `Certificate` with the specified resource name.
+  rpc GetCertificate(GetCertificateRequest) returns (Certificate) {}
+
   // Creates (adds) a `Certificate`.
   rpc CreateCertificate(CreateCertificateRequest) returns (Certificate) {}
 
@@ -35,6 +38,13 @@ service Certificates {
   // revocation state.
   rpc ReleaseCertificateHold(ReleaseCertificateHoldRequest)
       returns (Certificate) {}
+}
+
+// Request message for `GetCertificate` method.
+message GetCertificateRequest {
+  // Resource name.
+  string name = 1
+      [(google.api.resource_reference).type = "halo.wfanet.org/Certificate"];
 }
 
 // Request message for `CreateCertificate` method.

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -34,19 +34,19 @@ message DataProvider {
   // Resource name.
   string name = 1;
 
-  // The *preferred* X.509 certificate belonging to this `DataProvider` in DER
-  // format. Required.
-  bytes preferred_certificate_der = 2;
+  // The X.509 certificate belonging to this `DataProvider` in DER format which
+  // can be used to verify `public_key`. Required.
+  bytes certificate_der = 2;
 
-  // Resource name of the *preferred* `Certificate` belonging to this
-  // `DataProvider`. Output-only.
+  // Resource name of the `Certificate` belonging to this `DataProvider` which
+  // can be used to verify `public_key`. Output-only.
   //
-  // The `x509_der` field of this resource matches `preferred_certificate_der`.
-  string preferred_certificate = 3
+  // The `x509_der` field of this resource matches `certificate_der`.
+  string certificate = 3
       [(google.api.resource_reference).type = "halo.wfanet.org/Certificate"];
 
   // Serialized `EncryptionPublicKey` for this `DataProvider`, which can be
-  // verified using `preferred_certificate`. Required.
+  // verified using `certificate`. Required.
   SignedData public_key = 4;
 
   // Display name of the data provider.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
@@ -33,19 +33,19 @@ message MeasurementConsumer {
   // Resource name.
   string name = 1;
 
-  // The *preferred* X.509 certificate belonging to this `MeasurementConsumer`
-  // in DER format. Required.
-  bytes preferred_certificate_der = 2;
+  // The X.509 certificate belonging to this `MeasurementConsumer` in DER format
+  // which can be used to verify `public_key`. Required.
+  bytes certificate_der = 2;
 
-  // Resource name of the *preferred* `Certificate` belonging to this
-  // `MeasurementConsumer`. Output-only.
+  // Resource name of the `Certificate` belonging to this `MeasurementConsumer`
+  // which can be used to verify `public_key`. Output-only.
   //
-  // The `x509_der` field of this resource matches `preferred_certificate_der`.
-  string preferred_certificate = 3
+  // The `x509_der` field of this resource matches `certificate_der`.
+  string certificate = 3
       [(google.api.resource_reference).type = "halo.wfanet.org/Certificate"];
 
   // Serialized `EncryptionPublicKey` for this `MeasurementConsumer`, which can
-  // be verified using `preferred_certificate`. Required.
+  // be verified using `certificate`. Required.
   SignedData public_key = 4;
 
   // Official name of the `MeasurementConsumer`.


### PR DESCRIPTION
The existing messages stated that the public key signature for these resources can be verified using the current *preferred* certificate, but this is not always true (e.g. if a higher-preference certificate gets added).

The fields referring to preferred certificate have also been dropped from DataProvider and MeasurementConsumer. A caller can determine the preferred certificate (e.g. to pick a certificate when updating a resource's private key) by using the resource ID alias "preferred" in a GetCertificate request. See https://google.aip.dev/122#resource-id-aliases.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/37)
<!-- Reviewable:end -->
