### PR TITLE
Rename MeasurementConsumer title field to display_name.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
@@ -48,8 +48,8 @@ message MeasurementConsumer {
   // be verified using `certificate`. Required.
   SignedData public_key = 4;
 
-  // Official name of the `MeasurementConsumer`.
-  string title = 5;
+  // Display name of the `MeasurementConsumer`.
+  string display_name = 5;
 
   // Resource names of owner `Account`s. Output-only.
   repeated string owners = 6


### PR DESCRIPTION
There is no intent to require the display name to be unique, whereas that may be assumed for an official title.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/38)
<!-- Reviewable:end -->
