### PR TITLE
Split up Account creation and activation.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -229,7 +229,10 @@ proto_library(
 proto_library(
     name = "accounts_service_proto",
     srcs = ["accounts_service.proto"],
-    deps = [":account_proto"],
+    deps = [
+        ":account_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
 )
 
 proto_library(

--- a/src/main/proto/wfa/measurement/api/v2alpha/account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/account.proto
@@ -29,8 +29,62 @@ message Account {
     pattern: "accounts/{account}"
   };
 
+  enum View {
+    // The default/unset value.
+    //
+    // The API will default to the `BASIC` view unless otherwise specified by
+    // the method.
+    VIEW_UNSPECIFIED = 0;
+
+    // Basic view.
+    BASIC = 1;
+
+    // Full view.
+    FULL = 2;
+  }
+
   // Resource name.
   string name = 1;
+
+  // Resource name of the `Account` that created this one. Output-only.
+  // Immutable.
+  string creator = 2
+      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
+
+  // Possible activation state of an `Account`.
+  enum ActivationState {
+    ACTIVATION_STATE_UNSPECIFIED = 0;
+    // The `Account` has not yet been activated.
+    UNACTIVATED = 1;
+    // The `Account` has been activated. Terminal state.
+    ACTIVATED = 2;
+  }
+  // Activation state of this `Account`. Output-only.
+  ActivationState activation_state = 3;
+
+  // Parameters for activation of an `Account`.
+  message ActivationParams {
+    // Resource name of the `MeasurementConsumer` that this `Account` will be an
+    // owner of upon activation. Immutable.
+    //
+    // This can only be a `MeasurementConsumer` that `creator` is an owner of.
+    string owned_measurement_consumer = 1
+        [(google.api.resource_reference).type =
+             "halo.wfanet.org/MeasurementConsumer"];
+
+    // Token that can be used to activate the account. Output-only.
+    string activation_token = 2;
+  }
+  // Parameters for activation of this `Account`.
+  //
+  // Only set when `activation_state` is `UNACTIVATED` in `FULL` view.
+  ActivationParams activation_params = 4;
+
+  // Token that can be used to create a `MeasurementConsumer` resource.
+  // Output-only. Immutable.
+  //
+  // Only set in `FULL` view.
+  string measurement_consumer_creation_token = 5;
 
   // OpenID Connect identity.
   message OpenIdConnectIdentity {
@@ -41,10 +95,18 @@ message Account {
     string subject = 2;
   }
 
-  // Identity of the user for this `Account`. Required.
+  // An identity where the `Account` is identified by a unique username.
+  message UsernameIdentity {
+    // Unique username. Required.
+    string username = 1;
+  }
+
+  // Identity of the user for this `Account`. Output-only.
   //
-  // This value is unique across all `Account` resources.
+  // This must be set when `activation_state` is `ACTIVATED`. The specified
+  // value is unique across all `Account` resources.
   oneof identity {
-    OpenIdConnectIdentity open_id = 2;
+    OpenIdConnectIdentity open_id = 6;
+    UsernameIdentity username = 7;
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/accounts_service.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/resource.proto";
 import "wfa/measurement/api/v2alpha/account.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -25,10 +26,24 @@ option java_outer_classname = "AccountsServiceProto";
 // Service for interacting with `Account` resources.
 service Accounts {
   // Creates (registers) an `Account`.
+  //
+  // The `creator` will be derived from the authenticated caller. Results in
+  // PERMISSION_DENIED if the authenticated caller does not own the
+  // `owned_measurement_consumer` in `activation_params`.
+  //
+  // Returns the `FULL` view of the created `Account`.
   rpc CreateAccount(CreateAccountRequest) returns (Account) {}
 
-  // Updates an existing `Account`.
-  rpc UpdateAccount(UpdateAccountRequest) returns (Account) {}
+  // Activates an account by transitioning its `account_state` to `ACTIVATED`.
+  //
+  // The `identity` will be derived from the authenticated caller.
+  rpc ActivateAccount(ActivateAccountRequest) returns (Account) {}
+
+  // Replaces the `identity` of an `Account`.
+  //
+  // Results in PERMISSION_DENIED if the authenticated caller does not match the
+  // current `identity`.
+  rpc ReplaceAccountIdentity(ReplaceAccountIdentityRequest) returns (Account) {}
 
   // Logs the user in.
   rpc LogIn(LogInRequest) returns (LogInResponse) {}
@@ -40,18 +55,44 @@ service Accounts {
 
 // Request message for `CreateAccount` method.
 message CreateAccountRequest {
-  // The `Account` to create. Required. The `name` field will be
-  // ignored, and the system will assign an ID.
+  // The `Account` to create. Required. The `name` field will be ignored, and
+  // the system will assign an ID.
   Account account = 1;
 }
 
-// Request message for `UpdateAccount` method.
-message UpdateAccountRequest {
-  // The `Account` to update. Required.
-  Account account = 1;
+// Request message for `ActivateAccount` method.
+message ActivateAccountRequest {
+  // Resource name. Required.
+  string name = 1
+      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
 
-  // Encoded JSON Web Token (JWT) matching the updated identity. Required.
-  string identity_bearer_token = 2;
+  // Activation token. Required.
+  string activation_token = 2;
+}
+
+// Request message for `ReplaceAccountIdentity` method.
+message ReplaceAccountIdentityRequest {
+  // Resource name. Required.
+  string name = 1
+      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
+
+  message OpenIdConnectCredentials {
+    // Encoded JSON Web Token (JWT). Required.
+    string identity_bearer_token = 1;
+  }
+
+  message UsernameCredentials {
+    string username = 1;
+    string password = 2;
+  }
+
+  // Replacement credentials for an identity. Required.
+  oneof replacement_credentials {
+    // Replacement credentials for an `OpenIdConnectIdentity`.
+    OpenIdConnectCredentials open_id = 2;
+    // Replacement credentials for a `UsernameIdentity`.
+    UsernameCredentials username = 3;
+  }
 }
 
 message LogInRequest {}

--- a/src/main/proto/wfa/measurement/api/v2alpha/api_key.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/api_key.proto
@@ -22,11 +22,11 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ApiKeyProto";
 
-// Resource representing a revocable authentication key for this API.
+// Resource representing a revocable authentication key for an API resource.
 message ApiKey {
   option (google.api.resource) = {
     type: "halo.wfanet.org/ApiKey"
-    pattern: "accounts/{account}/apiKeys/{api_key}"
+    pattern: "measurementConsumers/{measurement_consumer}/apiKeys/{api_key}"
   };
 
   string name = 1;

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -51,10 +51,6 @@ message DataProvider {
 
   // Display name of the data provider.
   string display_name = 5;
-
-  // Resource names of owner `Account`s. Output-only.
-  repeated string owners = 6
-      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
 }
 
 // Wrapper for a list of `DataProvider` resource names.

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_providers_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_providers_service.proto
@@ -30,14 +30,6 @@ service DataProviders {
 
   // Creates (registers) a `DataProvider`.
   rpc CreateDataProvider(CreateDataProviderRequest) returns (DataProvider) {}
-
-  // Adds an owner to the specified `DataProvider`.
-  rpc AddDataProviderOwner(AddDataProviderOwnerRequest) returns (DataProvider) {
-  }
-
-  // Removes an owner from the specified `DataProvider`.
-  rpc RemoveDataProviderOwner(RemoveDataProviderOwnerRequest)
-      returns (DataProvider) {}
 }
 
 // Request message for `GetDataProvider` method.
@@ -52,28 +44,4 @@ message CreateDataProviderRequest {
   // The `DataProvider` to create. Required. The `key` field will be ignored,
   // and the system will assign an ID.
   DataProvider data_provider = 1;
-}
-
-// Request message for `AddDataProviderOwner` method.
-message AddDataProviderOwnerRequest {
-  // Resource name.
-  string name = 1
-      [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
-
-  // Resource name of the `Account` to add as an owner of this
-  // `DataProvider`. Required.
-  string account = 2
-      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
-}
-
-// Request message for `RemoveDataProviderOwner` method.
-message RemoveDataProviderOwnerRequest {
-  // Resource name.
-  string name = 1
-      [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
-
-  // Resource name of the `Account` to remove as an owner of this
-  // `DataProvider`. Required.
-  string account = 2
-      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
 }


### PR DESCRIPTION
This allows creation of Account resources for a different Account holder, where the Account holder will specify their identity and credentials when activating the Account. Accounts are now only used for MeasurementConsumer (MC) resources, and ApiKey resources each belong to a single MC. MC owners can create Accounts for any MC they own. Accounts for new MCs cannot be created via this API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/40)
<!-- Reviewable:end -->

https://rally1.rallydev.com/#/?detail=/task/609675021729&fdp=true