### PR TITLE
Remove `party` from ClaimReadyExchangeStepRequest

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -34,6 +34,9 @@ service ExchangeSteps {
   // If there are no ready ExchangeSteps, this will return an empty response.
   // Since this is expected, normal behavior, it does NOT return a NOT_FOUND
   // error.
+  //
+  // The caller must authenticate as either a DataProvider or a ModelProvider,
+  // and the returned ExchangeStep will belong to that party.
   rpc ClaimReadyExchangeStep(ClaimReadyExchangeStepRequest)
       returns (ClaimReadyExchangeStepResponse);
 }
@@ -47,14 +50,7 @@ message GetExchangeStepRequest {
 
 // Request message for `ClaimReadyExchangeStep` method.
 message ClaimReadyExchangeStepRequest {
-  // If an `ExchangeStep` is returned, it should be executed by this party.
-  // Required.
-  oneof party {
-    string data_provider = 1
-        [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
-    string model_provider = 2 [(google.api.resource_reference).type =
-                                   "halo.wfanet.org/ModelProvider"];
-  }
+  // Deliberately empty.
 }
 
 // Response message for `ClaimReadyExchangeStep` method.


### PR DESCRIPTION
Instead, rely on an authentication mechanism to provide the principal DataProvider or ModelProvider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/45)
<!-- Reviewable:end -->
