### PR TITLE
Add identification to the exchange_workflows

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -156,6 +156,9 @@ proto_library(
     name = "exchange_workflow_proto",
     srcs = ["exchange_workflow.proto"],
     strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
 )
 
 proto_library(

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
@@ -16,12 +16,14 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/resource.proto";
+
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeWorkflowProto";
 
-// A generic panel matching workflow. Many different pairs of parties may use
-// the same ExchangeWorkflow.
+// The representation for the Panel Matching Workflow. These are unique per
+// recurring exchange as they contain the identities of each party.
 //
 // See docs/panelmatch/example-exchange-workflow.textproto for an example
 // ExchangeWorkflow.
@@ -31,6 +33,13 @@ message ExchangeWorkflow {
     PARTY_UNSPECIFIED = 0;
     MODEL_PROVIDER = 1;
     DATA_PROVIDER = 2;
+  }
+
+  // The type of storage used for shared storage in a workflow.
+  enum StorageType {
+    UNKNOWN_STORAGE_CLIENT = 0;
+    GOOGLE_CLOUD_STORAGE = 1;
+    AMAZON_S3 = 2;
   }
 
   // Building blocks of the ExchangeWorkflow.
@@ -121,4 +130,23 @@ message ExchangeWorkflow {
 
   // Sequence of steps of the workflow.
   repeated Step steps = 1;
+
+  message ExchangeIdentifiers {
+    // Resource key of the Data Provider for the recurring exchange.
+    string data_provider = 2
+        [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
+
+    // Resource key of the Model Provider for the recurring exchange.
+    string model_provider = 3 [(google.api.resource_reference).type =
+                                   "halo.wfanet.org/ModelProvider"];
+
+    // Identifies which party is managing the shared storage client.
+    Party shared_storage_owner = 4;
+
+    // Identifies what chosen storage will be used to back the underlying
+    // StorageClient for shared storage.
+    StorageType storage = 5;
+  }
+
+  ExchangeIdentifiers exchange_identifiers = 2;
 }


### PR DESCRIPTION
This allows a party to identify which trusted cert should be used to
validate inputs as well as where shared storage is located (while
keeping that location hidden from the Kingdom).

These ids are:

1. A storage salt. To keep the location of shared storage secret from the kingdom (in case bucket security was misconfigured) this provides a salt value unknown to the kingdom (being encrypted) that, when concatenated with the exchange date and the other two values below will make a bucket name that is highly unique and unlikely to have a collision.

Note that the hash output will have to be limited to legal names for S3 and GCS buckets, IE: <64 characters, lowercase letters, numbers, and dashes (but not the first or last character).

2 & 3. the names of the EDP and MP certs in the clientCerts bundle. This follows the pattern of how requisiton.proto does things. 

The cert names will allow us grab the right certs for each exchange step attempt from clientCerts to validate the exchange_workflow itself and shared inputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/48)
<!-- Reviewable:end -->
