### PR TITLE
Drop HybridCipherSuite, specifying that info in EncryptionPublicKey.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/crypto.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/crypto.proto
@@ -44,46 +44,24 @@ message SignedData {
 
 // A public key for asymmetric encryption.
 message EncryptionPublicKey {
-  enum Type {
-    TYPE_UNSPECIFIED = 0;
+  enum Format {
+    FORMAT_UNSPECIFIED = 0;
 
-    // Elliptic curve key on the NIST P-256 curve.
+    // Tink Keyset format.
     //
-    // Algorithm identifier:
-    //   id-ecPublicKey
-    //   prime256v1
-    EC_P256 = 1;
+    // `data` is a serialized google.crypto.tink.Keyset message. Encrypted
+    // message values use Tink's wire format.
+    //
+    // See https://github.com/google/tink/blob/master/docs/WIRE-FORMAT.md,
+    // https://github.com/google/tink/blob/master/proto/tink.proto.
+    TINK_KEYSET = 1;
   }
-  // Type of encryption key. Required.
-  Type type = 1;
+  // Encryption key format. Required.
+  Format format = 1;
 
-  // The ASN.1 SubjectPublicKeyInfo in DER format. Required.
+  // The format-specific key data. Required.
   //
-  // The AlgorithmIdentifier must match `key_type`.
-  bytes public_key_info = 2;
-}
-
-// Description of a cipher suite for hybrid encryption using the KEM/DEM
-// paradigm.
-//
-// Values encrypted using one of these cipher suites include the sender KEM
-// public key.
-message HybridCipherSuite {
-  enum KeyEncapsulationMechanism {
-    KEY_ENCAPSULATION_MECHANISM_UNSPECIFIED = 0;
-
-    // ECDH over NIST P-256 with HKDF using HMAC-SHA256.
-    ECDH_P256_HKDF_HMAC_SHA256 = 1;
-  }
-  // The KEM for this cipher suite.
-  KeyEncapsulationMechanism kem = 1;
-
-  enum DataEncapsulationMechanism {
-    DATA_ENCAPSULATION_MECHANISM_UNSPECIFIED = 0;
-
-    // AES-128 with GCM.
-    AES_128_GCM = 1;
-  }
-  // The DEM for this cipher suite.
-  DataEncapsulationMechanism dem = 2;
+  // `format` and `data` together must specify all necessary information to
+  // decrypt messages given a private key.
+  bytes data = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -32,10 +32,6 @@ message MeasurementSpec {
   // `RequisitionSpec`.
   bytes measurement_public_key = 1;
 
-  // Hybrid encryption cipher suite for the `Measurement` that this
-  // `MeasurementSpec` is associated with. Required.
-  HybridCipherSuite cipher_suite = 2;
-
   message ReachAndFrequency {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams reach_privacy_params = 1;
@@ -46,6 +42,6 @@ message MeasurementSpec {
 
   // Fields specific to the type of measurement.
   oneof measurement_type {
-    ReachAndFrequency reach_and_frequency = 3;
+    ReachAndFrequency reach_and_frequency = 2;
   }
 }


### PR DESCRIPTION
Encryption keys are inherently tied to the algorithms used. Additionally, there is no standard format for specifying the parameters needed to decrypt a hybrid ciphertext. Therefore, EncryptionPublicKey remains flexible on what key formats it supports. This adds Tink's Keyset as a supported key format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/50)
<!-- Reviewable:end -->
