### PR TITLE
Move Schedule from RecurringExchange to ExchangeWorkflow.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
@@ -207,4 +207,13 @@ message ExchangeWorkflow {
 
   // The date of the first Exchange.
   google.type.Date first_exchange_date = 3;
+
+  message Schedule {
+    // Expects a valid CRON expression.
+    // See https://en.wikipedia.org/wiki/Cron#CRON_expression.
+    string cron_expression = 1;
+  }
+
+  // How often to run the `exchange_workflow`.
+  Schedule repetition_schedule = 3;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
@@ -39,9 +39,6 @@ message RecurringExchange {
   // The ExchangeWorkflow for this recurring exchange. Immutable.
   ExchangeWorkflow exchange_workflow = 2;
 
-  // How often to run the `exchange_workflow`.
-  Schedule repetition_schedule = 3;
-
   // The DataProvider party.
   string event_data_provider = 4
       [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
@@ -55,12 +52,6 @@ message RecurringExchange {
 
   // The date of the next Exchange.
   google.type.Date next_exchange_date = 7;
-
-  message Schedule {
-    // Expects a valid CRON expression.
-    // See https://en.wikipedia.org/wiki/Cron#CRON_expression.
-    string cron_expression = 1;
-  }
 
   enum State {
     STATE_UNSPECIFIED = 0;


### PR DESCRIPTION
To avoid bugs or attacks where arbitrarily many Exchanges are started, the schedule should be signed as part of the ExchangeWorkflow.