### PR TITLE
Use nonces for verification of DataProvider participation.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -42,21 +42,6 @@ message Measurement {
   // `measurement_consumer_certificate`. Required. Immutable.
   SignedData measurement_spec = 3;
 
-  // Serialized `DataProviderList` message containing the same `DataProvider`
-  // resource keys as `data_provider_entries`. The order of the entries does not
-  // matter. Required. Immutable.
-  //
-  // This is included as a separate field to provide a canonical serialization
-  // for hashing, as the protocol buffer binary encoding specification does not
-  // provide a deterministic serialization.
-  bytes serialized_data_provider_list = 4;
-
-  // A cryptographic salt for this `Measurement` that's used when computing the
-  // SHA256 hash of `serialized_data_provider_list`. Required. Immutable.
-  //
-  // A randomly-generated 32-byte value should be ample.
-  bytes data_provider_list_salt = 5;
-
   // TODO(b/175707034): Consider adding a field to hold the private keys which
   // is encrypted with some private/symmetric key belonging to the
   // `MeasurementConsumer`. This way the `MeasurementConsumer` need not store
@@ -82,20 +67,24 @@ message Measurement {
       // this entry, which can be verified using
       // `measurement_consumer_certificate`. Required.
       //
-      // The encryption uses the `cipher_suite` specified in `measurement_spec`,
-      // with `data_provider_public_key` as the recipient public key.
+      // The encryption uses `data_provider_public_key` as the recipient public
+      // key.
       bytes encrypted_requisition_spec = 3;
+
+      // SHA256 hash of the `nonce` from `encrypted_requisition_spec`, where the
+      // nonce value has big-endian byte ordering.
+      bytes nonce_hash = 4;
     }
     // Value of the map entry. Required.
     Value value = 2;
   }
   // Map of `DataProvider` name to parameters for that `DataProvider`. Required.
   // Immutable.
-  repeated DataProviderEntry data_providers = 6;
+  repeated DataProviderEntry data_providers = 4;
 
   // The `ProtocolConfig` selected for this measurement according to the
   // `measurement_spec`. Output-only. Immutable.
-  ProtocolConfig protocol_config = 7;
+  ProtocolConfig protocol_config = 5;
 
   enum State {
     STATE_UNSPECIFIED = 0;
@@ -110,7 +99,7 @@ message Measurement {
     // Cancelled by Measurement Consumer. Terminal state.
     CANCELLED = 5;
   }
-  State state = 8;
+  State state = 6;
 
   // The result of a `Measurement` computation.
   message Result {
@@ -133,15 +122,15 @@ message Measurement {
   // X.509 certificate in DER format which can be verified using the
   // Aggregator's root certificate. Output-only. Only set if `state` is
   // `SUCCEEDED`.
-  bytes aggregator_certificate = 9;
+  bytes aggregator_certificate = 7;
 
   // Encrypted `SignedData` containing the serialized `Result`, which can be
   // verified using `aggregator_certificate`. Output-only. Must be set if
   // `state` is `SUCCEEDED`.
   //
-  // The encryption uses the `cipher_suite` specified in `measurement_spec`,
-  // with `measurement_public_key` as the recipient public key.
-  bytes encrypted_result = 10;
+  // The encryption uses the `measurement_public_key` from `measurement_spec` as
+  // the recipient public key.
+  bytes encrypted_result = 8;
 
   // ID referencing the `Measurement` in an external system, provided by the
   // Measurement Consumer.
@@ -149,7 +138,7 @@ message Measurement {
   // If set, this value must be unique among `Measurement`s for the parent
   // `MeasurementConsumer`. This serves as an idempotency key for the
   // `Measurement`.
-  string measurement_reference_id = 11;
+  string measurement_reference_id = 9;
 
   message Failure {
     enum Reason {
@@ -167,5 +156,5 @@ message Measurement {
     string message = 2;
   }
   // Set when the state is set to FAILED. Output-only.
-  Failure failure = 12;
+  Failure failure = 10;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -31,6 +31,10 @@ message MeasurementSpec {
   // `RequisitionSpec`.
   bytes measurement_public_key = 1;
 
+  // List of `nonce_hash` values from `data_providers` of the corresponding
+  // `Measurement`. Required.
+  repeated bytes nonce_hashes = 2;
+
   message ReachAndFrequency {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams reach_privacy_params = 1;
@@ -41,6 +45,6 @@ message MeasurementSpec {
 
   // Fields specific to the type of measurement.
   oneof measurement_type {
-    ReachAndFrequency reach_and_frequency = 2;
+    ReachAndFrequency reach_and_frequency = 3;
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -115,15 +115,10 @@ message Requisition {
   // The state of this `Requisition`.
   State state = 10;
 
-  // Cryptographic digital signature of the "requisition fingerprint" which
-  // can be verified using the `data_provider_certificate`. Only set if `state`
-  // is `FULFILLED`.
+  // The `nonce` value from `encrypted_requisition_spec`. Output-only.
   //
-  // The requisition fingerprint is defined as the concatenation of:
-  // 1. The SHA256 hash of `encrypted_requisition_spec`.
-  // 2. `data_provider_list_hash` from `encrypted_requisition_spec`.
-  // 3. `data` from `measurement_spec`.
-  bytes data_provider_participation_signature = 11;
+  // Set when `state` is `FULFILLED`.
+  fixed64 nonce = 11;
 
   message Refusal {
     // Justification for refusing to fulfill a `Requisition`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -38,15 +38,16 @@ message FulfillRequisitionRequest {
     string name = 1
         [(google.api.resource_reference).type = "halo.wfanet.org/Requisition"];
 
-    // Cryptographic digital signature of the "requisition fingerprint" which
-    // can be verified using the `DataProvider`'s certificate. Required.
+    // The fingerprint of the `Requisition`. Required.
     //
-    // The requisition fingerprint is defined as the concatenation of:
-    // 1. The SHA256 hash of `encrypted_requisition_spec` from the
+    // This is defined as the SHA256 hash of the concatenation of:
+    // 1. The `data` in `measurement_spec` from the `Requisition`.
+    // 2. The SHA256 hash of `encrypted_requisition_spec` from the
     //    `Requisition`.
-    // 2. `data_provider_list_hash` from the `Requisition`.
-    // 3. The `data` in `measurement_spec` from the `Requisition`.
-    bytes data_provider_participation_signature = 2;
+    bytes requisition_fingerprint = 2;
+
+    // The `nonce` value from the `encrypted_requisition_spec`. Required.
+    fixed64 nonce = 3;
   }
 
   // The chunk message for this streaming request.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
@@ -24,6 +24,7 @@ option java_multiple_files = true;
 option java_outer_classname = "RequisitionSpecProto";
 
 // Specification for a `Requisition` which can be cryptographically signed.
+// Immutable.
 message RequisitionSpec {
   // Filter to apply to events.
   message EventFilter {
@@ -72,23 +73,20 @@ message RequisitionSpec {
     Value value = 2;
   }
   // Map of `EventGroup` name to parameters for that `EventGroup`. Required.
-  // Immutable.
   //
   // All of the `EventGroup`s must belong to the same parent `DataProvider`
   // as this `Requisition`.
   repeated EventGroupEntry event_groups = 1;
 
   // Serialized `EncryptionPublicKey` for the `Measurement` that this
-  // `RequisitionSpec` is associated with. Required. Immutable.
+  // `RequisitionSpec` is associated with. Required.
   //
   // This is serialized so it can be easily compared with the same field in
   // `MeasurementSpec`.
   bytes measurement_public_key = 2;
 
-  // SHA256 hash of the concatenation of `serialized_data_provider_list` and
-  // `data_provider_list_salt` from the `Measurement` that this
-  // `RequisitionSpec` is associated with. Required. Immutable.
-  bytes data_provider_list_hash = 3;
+  // Non-zero cryptographic nonce for this `RequisitionSpec`. Required.
+  fixed64 nonce = 3;
 }
 
 // A time interval.


### PR DESCRIPTION
This way, each Duchy only learns the identity of the DataProviders that directly interact with them. Due to the fact that DataProvider->Duchy communication uses mTLS, data sent from DataProviders to Duchies need not be digitally signed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/62)
<!-- Reviewable:end -->

https://rally1.rallydev.com/#/?detail=/task/613528080807&fdp=true