### PR TITLE
Deprecate measurement_consumer_creation_token in Account

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/account.proto
@@ -49,7 +49,7 @@ message Account {
   // Resource name of the `Account` that created this one. Output-only.
   // Immutable.
   string creator = 2
-  [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
+      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
 
   // Possible activation state of an `Account`.
   enum ActivationState {
@@ -69,8 +69,8 @@ message Account {
     //
     // This can only be a `MeasurementConsumer` that `creator` is an owner of.
     string owned_measurement_consumer = 1
-    [(google.api.resource_reference).type =
-        "halo.wfanet.org/MeasurementConsumer"];
+        [(google.api.resource_reference).type =
+             "halo.wfanet.org/MeasurementConsumer"];
 
     // Token that can be used to activate the account. Output-only.
     string activation_token = 2;

--- a/src/main/proto/wfa/measurement/api/v2alpha/account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/account.proto
@@ -80,7 +80,7 @@ message Account {
   // Only set when `activation_state` is `UNACTIVATED` in `FULL` view.
   ActivationParams activation_params = 4;
 
-  // DEPRECATED: suppose not to owned by an Account
+  // DEPRECATED: suppose not to be owned by an Account
   string measurement_consumer_creation_token = 5 [deprecated = true];
 
   // OpenID Connect identity.

--- a/src/main/proto/wfa/measurement/api/v2alpha/account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/account.proto
@@ -49,7 +49,7 @@ message Account {
   // Resource name of the `Account` that created this one. Output-only.
   // Immutable.
   string creator = 2
-      [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
+  [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
 
   // Possible activation state of an `Account`.
   enum ActivationState {
@@ -69,8 +69,8 @@ message Account {
     //
     // This can only be a `MeasurementConsumer` that `creator` is an owner of.
     string owned_measurement_consumer = 1
-        [(google.api.resource_reference).type =
-             "halo.wfanet.org/MeasurementConsumer"];
+    [(google.api.resource_reference).type =
+        "halo.wfanet.org/MeasurementConsumer"];
 
     // Token that can be used to activate the account. Output-only.
     string activation_token = 2;
@@ -80,11 +80,8 @@ message Account {
   // Only set when `activation_state` is `UNACTIVATED` in `FULL` view.
   ActivationParams activation_params = 4;
 
-  // Token that can be used to create a `MeasurementConsumer` resource.
-  // Output-only. Immutable.
-  //
-  // Only set in `FULL` view.
-  string measurement_consumer_creation_token = 5;
+  // DEPRECATED: suppose not to owned by an Account
+  string measurement_consumer_creation_token = 5 [deprecated = true];
 
   // OpenID Connect identity.
   message OpenIdConnectIdentity {


### PR DESCRIPTION
No usage of `Account/measurement_consumer_creation_token` so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/88)
<!-- Reviewable:end -->
