### PR TITLE
Add a name field to Event Template Descriptor

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
@@ -31,10 +31,16 @@ message EventFieldDescriptor {
 
 // Metadata about an Event Template.
 message EventTemplateDescriptor {
+  // Name used to reference this Event Template. Required, Immutable.
+  // Must follow the naming convention for protocol buffers fields.
+  // See https://developers.google.com/protocol-buffers/docs/style
+  // Must be unique among all event template message types within
+  // a given template library.
+  string name = 1;
   // Human-readable name of the Event Template. Required.
-  string display_name = 1;
+  string display_name = 2;
   // High-level description of the Event Template.
-  string description = 2;
+  string description = 3;
 }
 
 // Custom options for messages. Numbering starts at 50000 which is the start of


### PR DESCRIPTION
This field will be used to reference the template e.g. when using it in a cel expression for filtering

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/92)
<!-- Reviewable:end -->
