### PR TITLE
Update CopyFromPreviousExchangeStep so that the to-be-copied blob's key is not in the input labels map.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
@@ -169,8 +169,17 @@ message ExchangeWorkflow {
     // Preprocesses data for later use by ExecutePrivateMembershipQueriesStep
     message PreprocessEventsStep {}
 
-    // Copies an input from a previous exchange into this one.
-    message CopyFromPreviousExchangeStep {}
+    // Copies a blob from a previous exchange into this one. Requires a single
+    // output label "output".
+    //
+    // If this is the first exchange in a recurring exchange, this step is
+    // treated as an `InputStep` that awaits the existence of the indicated
+    // output blob key. For all subsequent exchanges, this step copies the blob
+    // named `previous_blob_key` from the previous exchange and writes it to
+    // the indicated output blob key.
+    message CopyFromPreviousExchangeStep {
+      string previous_blob_key = 1;
+    }
 
     // Hashes a set of decrypted join keys
     message GenerateLookupKeysStep {}


### PR DESCRIPTION
Currently the key of the blob being copied is specified in the input labels map. This doesn't make sense when trying to copy a blob from a *previous* exchange, because input labels only refer to blobs within the *current* exchange (see [ExchangeTaskExecutor.kt](https://github.com/world-federation-of-advertisers/panel-exchange-client/blob/c11195a7df4f7f967a1ff1ff8ce6f92ab804a215/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt#L71-L77)). This is causing CopyFromPreviousExchangeStep to fail in the case where the blob gets copied with the same blob key each exchange, because the input blob does not yet exist in the *current* exchange's storage.

With this proposal, CopyFromPreviousExchangeStep would not need to use input labels map at all, as the key of the blob to be copied is explicitly specified in the step's fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/96)
<!-- Reviewable:end -->
