### PR TITLE
Move creation token field from CreateMeasurementConsumerRequest.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
@@ -54,4 +54,7 @@ message MeasurementConsumer {
   // Resource names of owner `Account`s. Output-only.
   repeated string owners = 6
       [(google.api.resource_reference).type = "halo.wfanet.org/Account"];
+
+  // Token to create a `MeasurementConsumer` resource. Required. Input-only.
+  string measurement_consumer_creation_token = 7;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumers_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumers_service.proto
@@ -54,9 +54,6 @@ message CreateMeasurementConsumerRequest {
   // The `MeasurementConsumer` to create. Required. The `name` field will be
   // ignored, and the system will assign an ID.
   MeasurementConsumer measurement_consumer = 1;
-
-  // Token to create a `MeasurementConsumer` resource. Required.
-  string measurement_consumer_creation_token = 2;
 }
 
 // Request message for `AddMeasurementConsumerOwner` method.


### PR DESCRIPTION
From https://google.aip.dev/133:
> The request message **must not** contain any other required fields and should not contain other optional fields except those described in this or another AIP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement-api/110)
<!-- Reviewable:end -->
