### PR TITLE
Use ubuntu-20.04 runner for Bazel build & test action.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build-test:
     name: Build and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out revision
         uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu-18.04 runner is deprecated and scheduled for impending removal.