### PR TITLE
add ErrorDetails message to measurement proto message

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -163,6 +163,7 @@ proto_library(
         ":protocol_config_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -20,6 +20,7 @@ import "google/api/resource.proto";
 import "google/protobuf/duration.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/protocol_config.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -172,6 +173,22 @@ message Measurement {
     // information.
     string message = 2;
   }
+  // DEPRECATED: failure information are available in the ErrorDetails message.
   // Set when the state is set to FAILED. Output-only.
-  Failure failure = 10;
+  Failure failure = 10 [deprecated = true];
+
+  message ErrorDetails {
+    enum Type {
+      TYPE_UNSPECIFIED = 0;
+      TRANSIENT = 1;
+      PERMANENT = 2;
+    }
+    Type type = 1;
+
+    // Time that the error occurred.
+    google.protobuf.Timestamp error_time = 2;
+  }
+
+  // Set when the state is set to FAILED. Output-only.
+  ErrorDetails error = 11;
 }


### PR DESCRIPTION
Adding ErrorDetails proto message to public API. 
In case of a measurement failure, the error is not inside Measurement.Details anymore.