### PR TITLE
Add reach measurement type

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -45,6 +45,11 @@ message MeasurementSpec {
   // Range of VIDs that will be included in this measurement
   VidSamplingInterval vid_sampling_interval = 3;
 
+  message Reach {
+    // Differential privacy parameters for reach.
+    DifferentialPrivacyParams privacy_params = 1;
+  }
+
   message ReachAndFrequency {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams reach_privacy_params = 1;
@@ -76,6 +81,7 @@ message MeasurementSpec {
 
   // Fields specific to the type of measurement.
   oneof measurement_type {
+    Reach reach = 7;
     ReachAndFrequency reach_and_frequency = 4;
     Impression impression = 5;
     Duration duration = 6;

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -81,9 +81,9 @@ message MeasurementSpec {
 
   // Fields specific to the type of measurement.
   oneof measurement_type {
-    Reach reach = 7;
     ReachAndFrequency reach_and_frequency = 4;
     Impression impression = 5;
     Duration duration = 6;
+    Reach reach = 7;
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -39,6 +39,7 @@ message ProtocolConfig {
     REACH_AND_FREQUENCY = 1;
     IMPRESSION = 2;
     DURATION = 3;
+    REACH = 4;
   }
   // The type of measurement that this protocol computes. Required. Immutable.
   MeasurementType measurement_type = 2;


### PR DESCRIPTION
Adding reach measurement type to the CMM public API. This change is motivated by the following facts
1. Reach-only queries are important and frequently used, and we have different optimization for it.
2. Protocol update for reach-only is coming up. A separate measurement type from reach-frequency makes it easier.