### PR TITLE
Add request_id field to some Create requests as per AIP-155.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -53,9 +53,6 @@ message EventGroup {
 
   // ID referencing the `EventGroup` in an external system, provided by the
   // `DataProvider`.
-  //
-  // If set, this value must be unique among `EventGroup`s for the parent
-  // `DataProvider`.
   string event_group_reference_id = 5;
 
   // The set of VID model lines used to label events in this `EventGroup`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -66,10 +66,14 @@ message CreateEventGroupRequest {
 
   // The `EventGroup` to create. Required.
   //
-  // The `key` field will be ignored, and the system will assign an ID. Results
-  // in an `ALREADY_EXISTS` error if there is already a child `EventGroup` with
-  // the same `event_group_reference_id`.
+  // The `name` field will be ignored, and the system will assign an ID.
   EventGroup event_group = 2;
+
+  // Unique identifier for this request.
+  //
+  // If specified, the request will be idempotent. See
+  // https://google.aip.dev/155.
+  string request_id = 3;
 }
 
 // Request message for `UpdateEventGroup` method.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -151,10 +151,6 @@ message Measurement {
 
   // ID referencing the `Measurement` in an external system, provided by the
   // Measurement Consumer.
-  //
-  // If set, this value must be unique among `Measurement`s for the parent
-  // `MeasurementConsumer`. This serves as an idempotency key for the
-  // `Measurement`.
   string measurement_reference_id = 9;
 
   message Failure {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -51,9 +51,15 @@ message GetMeasurementRequest {
 
 // Request message for `CreateMeasurement` method.
 message CreateMeasurementRequest {
-  // The `Measurement` to create. Required. The `key` field will be
-  // ignored, and the system will assign an ID.
+  // The `Measurement` to create. Required. The `name` field will be ignored,
+  // and the system will assign an ID.
   Measurement measurement = 1;
+
+  // Unique identifier for this request.
+  //
+  // If specified, the request will be idempotent. See
+  // https://google.aip.dev/155.
+  string request_id = 2;
 }
 
 // Request message for `ListMeasurements` method.


### PR DESCRIPTION
This replaces all other idempotency key mechanisms. As a result, it is a backwards-incompatible change.