### PR TITLE
Update CreateModelRelease request

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/model_releases_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_releases_service.proto
@@ -42,10 +42,6 @@ message CreateModelReleaseRequest {
     (google.api.resource_reference).type = "halo.wfanet.org/ModelSuite",
     (google.api.field_behavior) = REQUIRED
   ];
-
-  // The `ModelRelease` to create. The `name` field will be
-  // ignored, and the system will assign an ID.
-  ModelRelease model_release = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message GetModelReleaseRequest {


### PR DESCRIPTION
Remove required ```ModelRelease``` resource from ```CreateModelReleaseRequest```. ```ModelRelease``` contains nothing but a link to parent resources that are already specified in the request.