### PR TITLE
Add a `parent` field to ClaimReadyExchangeStepRequest.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -28,12 +28,12 @@ option java_outer_classname = "ExchangeStepsServiceProto";
 
 // Service for interacting with `ExchangeStep` resources.
 service ExchangeSteps {
-  // Claims a single ExchangeStep that is ready to be worked on and creates an
-  // initial ExchangeStepAttempt for it.
+  // Finds the first `ExchangeStep` for the caller under the specified
+  // `recurringExchanges` collection that is ready to be worked on and claims
+  // it, creating an initial `ExchangeStepAttempt` for it.
   //
-  // If there are no ready ExchangeSteps, this will return an empty response.
-  // Since this is expected, normal behavior, it does NOT return a NOT_FOUND
-  // error.
+  // This may create `Exchange` and `ExchangeStep` resources under the
+  // collection.
   rpc ClaimReadyExchangeStep(ClaimReadyExchangeStepRequest)
       returns (ClaimReadyExchangeStepResponse);
 
@@ -46,25 +46,23 @@ service ExchangeSteps {
 
 // Request message for `ClaimReadyExchangeStep` method.
 message ClaimReadyExchangeStepRequest {
-  // If an `ExchangeStep` is returned, it should be executed by this party.
-  // Required.
-  oneof party {
-    // Resource name of parent `DataProvider`.
-    string data_provider = 1
-        [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
-    // Resource name of parent `ModelProvider`.
-    string model_provider = 2 [(google.api.resource_reference).type =
-                                   "halo.wfanet.org/ModelProvider"];
-  }
+  reserved 1, 2;
+
+  // Resource name of the parent of the `recurringExchanges` collection.
+  string parent = 3 [
+    (google.api.resource_reference).child_type =
+        "halo.wfanet.org/RecurringExchange",
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // Response message for `ClaimReadyExchangeStep` method.
-// If there are no ready `ExchangeSteps`, all fields will be unset.
 message ClaimReadyExchangeStepResponse {
-  // The `ExchangeStep`.
+  // If an `ExchangeStep` was claimed, that resource.
   ExchangeStep exchange_step = 1;
 
-  // Resource name of a new ExchangeStepAttempt for `exchange_step`.
+  // If an `ExchangeStep` was claimed, the resource name of the resulting
+  // `ExchangeStepAttempt`.
   string exchange_step_attempt = 2 [(google.api.resource_reference).type =
                                         "halo.wfanet.org/ExchangeStepAttempt"];
 }


### PR DESCRIPTION
The method operates on the recurringExchanges resource collection.