### PR TITLE
Fix api-lint tool missing some well-known dependencies.

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -40,4 +40,4 @@ jobs:
 
     - env:
         BAZEL: bazelisk
-      run: tools/api-lint
+      run: tools/api-lint wfa

--- a/tools/api-lint
+++ b/tools/api-lint
@@ -1,21 +1,77 @@
 #!/usr/bin/env bash
+# Copyright 2023 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run api-linter with appropriate dependencies.
+#
+# Usage: api-lint PATH [OPTION]...
+# Params:
+#   PATH  Path relative to PROTO_PATH under which to find *.proto files.
 
 set -eu -o pipefail
 
 readonly BAZEL="${BAZEL:-bazel}"
 readonly PROTO_PATH='src/main/proto'
 
-declare bazel_bin
-bazel_bin="$("$BAZEL" info bazel-bin)"
+build() {
+  "$BAZEL" query "kind('^proto_library rule', @com_github_protocolbuffers_protobuf//:all + @com_google_googleapis//google/type:all + @com_google_googleapis//google/api:all)" --output=label |
+    xargs "$BAZEL" build
+}
 
-"$BAZEL" query "kind(proto_library, $PROTO_PATH/...)" | xargs "$BAZEL" build
+get_descriptor_sets() {
+  readonly external_path="${bazel_bin}/external"
+  find "${external_path}" \
+    -name '*-descriptor-set.proto.bin' \! -name '*test*' \
+    \( \
+      -path "${external_path}/com_github_protocolbuffers_protobuf/*" \
+      -o \
+      -path "${external_path}/com_google_googleapis/google/type/*" \
+      -o \
+      -path "${external_path}/com_google_googleapis/google/api/*" \
+    \)
 
-find "$PROTO_PATH" -name '*.proto' -printf '%P\0' |
-  xargs -0 api-linter --proto-path "$PROTO_PATH" \
-  --config "$PROTO_PATH/api-linter.yaml" --set-exit-status \
-  --descriptor-set-in "${bazel_bin}/external/com_github_protocolbuffers_protobuf/descriptor_proto-descriptor-set.proto.bin" \
-  --descriptor-set-in "${bazel_bin}/external/com_google_googleapis/google/type/date_proto-descriptor-set.proto.bin" \
-  --descriptor-set-in "${bazel_bin}/external/com_google_googleapis/google/api/resource_proto-descriptor-set.proto.bin" \
-  --descriptor-set-in "${bazel_bin}/external/com_google_googleapis/google/api/field_behavior_proto-descriptor-set.proto.bin" \
-  --descriptor-set-in "${bazel_bin}/external/com_google_googleapis/google/api/client_proto-descriptor-set.proto.bin" \
-  "$@"
+}
+
+get_proto_files() {
+  find "$PROTO_PATH" \
+    -path "$PROTO_PATH/${path}/*" \
+    -name '*.proto' \
+    -printf '%P\0'
+}
+
+lint() {
+  declare -a api_linter_args=(
+    '--set-exit-status'
+    "--proto-path=$PROTO_PATH"
+    "--config=$PROTO_PATH/api-linter.yaml"
+  )
+  for descriptor_set in $(get_descriptor_sets); do
+    api_linter_args+=( "--descriptor-set-in=${descriptor_set}" )
+  done
+
+  get_proto_files | xargs -0 api-linter "${api_linter_args[@]}" "$@"
+}
+
+main() {
+  readonly path="$1"
+  shift 1
+
+  declare bazel_bin
+  bazel_bin="$("$BAZEL" info bazel-bin)"
+
+  build
+  lint "$@"
+}
+
+main "$@"


### PR DESCRIPTION
This addresses an issue introduced in #155.