### PR TITLE
Add direct computation methodologies to protocol config and measurement results

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -166,6 +166,15 @@ proto_library(
 )
 
 proto_library(
+    name = "direct_computation_proto",
+    srcs = ["direct_computation.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+    ],
+)
+
+proto_library(
     name = "protocol_config_proto",
     srcs = ["protocol_config.proto"],
     strip_import_prefix = IMPORT_PREFIX,
@@ -181,6 +190,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":crypto_proto",
+        ":direct_computation_proto",
         ":protocol_config_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
@@ -1,0 +1,66 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.api.v2alpha;
+
+import "google/api/field_behavior.proto";
+
+option java_package = "org.wfanet.measurement.api.v2alpha";
+option java_multiple_files = true;
+option java_outer_classname = "DirectComputationProto";
+
+// Parameters used when applying the deterministic count distinct methodology.
+message DeterministicCountDistinct {}
+
+// Parameters used when applying the deterministic distribution methodology.
+message DeterministicDistribution {}
+
+// Parameters used when applying the deterministic count methodology.
+message DeterministicCount {}
+
+// Parameters used when applying the deterministic sum methodology.
+message DeterministicSum {}
+
+// Parameters used when applying the Liquid Legions count distinct methodology.
+//
+// May only be set when the measurement type is REACH.
+// To obtain differentially private result, one should add a DP noise to the
+// estimate number of sampled registers instead of the target estimate.
+message LiquidLegionsCountDistinct {
+  // The decay rate of the Liquid Legions sketch.
+  double decay_rate = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The maximum size of the Liquid Legions sketch.
+  int64 max_size = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Parameters used when applying the Liquid Legions distribution methodology.
+//
+// May only be set in frequency result when the measurement type is
+// REACH_AND_FREQUENCY.
+// `Requisition`s using this protocol can be fulfilled by calling
+// RequisitionFulfillment/FulfillRequisition with an encrypted sketch.
+// When using this LiquidLegionsDistribution methodology, EDPs must use enough
+// number of bits to represent the fingerprints in the LiquidLegions. That is,
+// you should avoid the possibility of representing two VIDs as the same
+// fingerprint."
+message LiquidLegionsDistribution {
+  // The decay rate of the Liquid Legions sketch.
+  double decay_rate = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The maximum size of the Liquid Legions sketch.
+  int64 max_size = 2 [(google.api.field_behavior) = REQUIRED];
+}

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -21,6 +21,7 @@ import "google/api/resource.proto";
 import "google/protobuf/duration.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/protocol_config.proto";
+import "wfa/measurement/api/v2alpha/direct_computation.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -126,6 +127,27 @@ message Measurement {
     message Reach {
       // Number of unique users exposed.
       int64 value = 1;
+
+      // The mechanism used to generate noise during computation.
+      //
+      // While this **should** always be set, if it is not then it implies
+      // `CONTINUOUS_LAPLACE`.
+      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
+      // changes.
+      ProtocolConfig.NoiseMechanism noise_mechanism = 2;
+
+      // The computation methodology done by data provider.
+      //
+      // Currently, only direct measurement would populate it. Before all EDPs
+      // incorporate the new API, if no methodology is set for the direct reach
+      // result, it is assumed that DeterministicCountDistinct is used.
+      oneof methodology {
+        // Deterministic count distinct methodology.
+        DeterministicCountDistinct deterministic_count_distinct = 3;
+
+        // Liquid Legions count distinct methodology.
+        LiquidLegionsCountDistinct liquid_legions_count_distinct = 4;
+      }
     }
     // The reach result.
     Reach reach = 1;
@@ -137,6 +159,27 @@ message Measurement {
       // times, unless 4 is the largest key (maximum frequency) in which case it
       // means that 33.3% of users were exposed at least 4 times.
       map<int64, double> relative_frequency_distribution = 1;
+
+      // The mechanism used to generate noise during computation.
+      //
+      // While this **should** always be set, if it is not then it implies
+      // `CONTINUOUS_LAPLACE`.
+      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
+      // changes.
+      ProtocolConfig.NoiseMechanism noise_mechanism = 2;
+
+      // The computation methodology done by data provider.
+      //
+      // Currently, only direct measurement would populate it. Before all EDPs
+      // incorporate the new API, if no methodology is set for the direct
+      // frequency result, it is assumed that DeterministicDistribution is used.
+      oneof methodology {
+        // Deterministic distribution methodology.
+        DeterministicDistribution deterministic_distribution = 3;
+
+        // Liquid Legions distribution methodology.
+        LiquidLegionsDistribution liquid_legions_distribution = 4;
+      }
     }
     // The frequency result.
     Frequency frequency = 2;
@@ -145,14 +188,50 @@ message Measurement {
     message Impression {
       // Number of total impressions.
       int64 value = 1;
+
+      // The mechanism used to generate noise during computation.
+      //
+      // While this **should** always be set, if it is not then it implies
+      // `CONTINUOUS_LAPLACE`.
+      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
+      // changes.
+      ProtocolConfig.NoiseMechanism noise_mechanism = 2;
+
+      // The computation methodology done by data provider.
+      //
+      // Currently, only direct measurement would populate it. Before all EDPs
+      // incorporate the new API, if no methodology is set for the impression
+      // result, it is assumed that DeterministicCount is used.
+      oneof methodology {
+        // Deterministic count methodology.
+        DeterministicCount deterministic_count = 3;
+      }
     }
-    // The impressio result.
+    // The impression result.
     Impression impression = 3;
 
     // A watch duration result.
     message WatchDuration {
       // Total duration.
       google.protobuf.Duration value = 1;
+
+      // The mechanism used to generate noise during computation.
+      //
+      // While this **should** always be set, if it is not then it implies
+      // `CONTINUOUS_LAPLACE`.
+      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
+      // changes.
+      ProtocolConfig.NoiseMechanism noise_mechanism = 2;
+
+      // The computation methodology done by data provider.
+      //
+      // Currently, only direct measurement would populate it. Before all EDPs
+      // incorporate the new API, if no methodology is set for the watch
+      // duration result, it is assumed that DeterministicSum is used.
+      oneof methodology {
+        // Deterministic sum methodology.
+        DeterministicSum deterministic_sum = 3;
+      }
     }
     // The watch duration result.
     WatchDuration watch_duration = 4;
@@ -161,6 +240,13 @@ message Measurement {
     message Population {
       // The population value.
       int64 value = 1;
+
+      // The computation methodology done by data provider. Currently, only
+      // direct measurement would populate it.
+      oneof methodology {
+        // Deterministic count methodology.
+        DeterministicCount deterministic_count = 3;
+      }
     }
     // The population result.
     Population population = 5;

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -58,14 +58,21 @@ message ProtocolConfig {
   ];
 
   // The mechanism used to generate noise in computations.
+  //
+  // (-- TODO(@riemanli): Move the noise mechanism to its own file. --)
   enum NoiseMechanism {
     // Default value used if the mechanism is omitted.
     NOISE_MECHANISM_UNSPECIFIED = 0;
-
-    // Geometric.
+    // No noise is added.
+    NONE = 3;
+    // Geometric, i.e. discrete Laplace.
     GEOMETRIC = 1;
     // Discrete Gaussian.
     DISCRETE_GAUSSIAN = 2;
+    // Continuous Laplace.
+    CONTINUOUS_LAPLACE = 4;
+    // Continuous Gaussian.
+    CONTINUOUS_GAUSSIAN = 5;
   }
 
   // Configuration for the Liquid Legions v2 R/F protocol.
@@ -89,11 +96,72 @@ message ProtocolConfig {
     int32 maximum_frequency = 4;
 
     // The mechanism to generate noise during computation.
+    //
+    // Only discrete types are allowed.
     NoiseMechanism noise_mechanism = 5;
   }
 
   // Configuration for the Direct protocol.
-  message Direct {}
+  //
+  // The `DataProvider` may choose from the specified noise mechanisms and
+  // methodologies.
+  message Direct {
+    // Configuration parameters for the deterministic count distinct
+    // methodology.
+    message DeterministicCountDistinct {}
+    // Configuration parameters for the deterministic distribution methodology.
+    message DeterministicDistribution {}
+    // Configuration parameters for the deterministic count methodology.
+    message DeterministicCount {}
+    // Configuration parameters for the deterministic sum methodology.
+    message DeterministicSum {}
+    // Configuration parameters for the direct Liquid Legions distribution
+    // methodology.
+    //
+    // (-- TODO(@riemanli): Add recommended parameter values. --)
+    message LiquidLegionsDistribution {}
+    // Configuration parameters for the direct Liquid Legions count distinct
+    // methodology.
+    //
+    // (-- TODO(@riemanli): Add recommended parameter values. --)
+    message LiquidLegionsCountDistinct {}
+
+    // The set of mechanisms that can be used to generate noise during
+    // computation.
+    //
+    // Only continuous types and NONE are allowed.
+    repeated NoiseMechanism noise_mechanisms = 1;
+
+    // Deterministic count distinct methodology.
+    //
+    // Can be used in reach computations.
+    DeterministicCountDistinct deterministic_count_distinct = 2;
+
+    // Deterministic distribution methodology.
+    //
+    // Can be used in frequency computations.
+    DeterministicDistribution deterministic_distribution = 3;
+
+    // Deterministic count methodology.
+    //
+    // Can be used in impression and population computations.
+    DeterministicCount deterministic_count = 4;
+
+    // Deterministic sum methodology.
+    //
+    // Can be used in watch duration computations.
+    DeterministicSum deterministic_sum = 5;
+
+    // Liquid Legions count distinct methodology.
+    //
+    // Can be used in reach computations.
+    LiquidLegionsCountDistinct liquid_legions_count_distinct = 6;
+
+    // Liquid Legions distribution methodology.
+    //
+    // Can be used in frequency computations.
+    LiquidLegionsDistribution liquid_legions_distribution = 7;
+  }
 
   // Configuration for the Reach-Only Liquid Legions v2 protocol.
   message ReachOnlyLiquidLegionsV2 {
@@ -113,6 +181,8 @@ message ProtocolConfig {
     int32 elliptic_curve_id = 3 [(google.api.field_behavior) = REQUIRED];
 
     // The mechanism to generate noise during computation.
+    //
+    // Only discrete types are allowed.
     NoiseMechanism noise_mechanism = 4;
   }
 


### PR DESCRIPTION
This PR captures the choice of direct computation methodology from a data provider and the information needed to compute result variances. The parameters that the Kingdom chooses (e.g. available methodologies) go in the ProtocolConfig. The parameters that the result provider chooses (e.g. which methodology of those available) go in the Measurement result.

Note that the methodology chosen by the data provider shouldn't be seen by the entities other than the measurement consumer, so it is encrypted and is part of the measurement result.