### PR TITLE
Clarify specification of maximum frequency.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -63,8 +63,13 @@ message MeasurementSpec {
     // Differential privacy parameters for frequency.
     DifferentialPrivacyParams frequency_privacy_params = 2;
 
-    // Maximum frequency per user that will be included in this measurement.
-    int32 maximum_frequency_per_user = 3;
+    // The maximum frequency to reveal in the distribution.
+    //
+    // This is required in new `CreateMeasurement` requests, but may not be
+    // specified for legacy `Measurement`s. In the case where it is not
+    // specified, it must instead be read from the corresponding field in
+    // `ProtocolConfig`.
+    int32 maximum_frequency = 3;
   }
 
   // Parameters for an impression measurement.
@@ -78,15 +83,14 @@ message MeasurementSpec {
 
   // Parameters for a duration measurement.
   message Duration {
+    reserved 3;
+
     // Differential privacy parameters.
     DifferentialPrivacyParams privacy_params = 1;
 
     // Maximum watch duration in seconds per user that will be included in this
     // measurement.
     int32 maximum_watch_duration_per_user = 2;
-
-    // Maximum frequency per user that will be included in this measurement.
-    int32 maximum_frequency_per_user = 3;
   }
 
   // Parameters for a population measurement.

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -93,7 +93,10 @@ message ProtocolConfig {
     int32 elliptic_curve_id = 3 [(google.api.field_behavior) = REQUIRED];
 
     // The maximum frequency to reveal in the histogram.
-    int32 maximum_frequency = 4;
+    //
+    // Deprecated: Specified in MeasurementSpec instead except for legacy
+    // Measurements.
+    int32 maximum_frequency = 4 [deprecated = true];
 
     // The mechanism to generate noise during computation.
     //


### PR DESCRIPTION
* Deprecate the `maximum_frequency` field in `ProtocolConfig.LiquidLegionsV2` so it is no longer specified in two places.
* Rename `maximum_frequency_per_user` in `MeasurementSpec.ReachAndFrequency` to `maximum_frequency`, clarifying the requirements.
* Drop the unsupported `maximum_frequency_per_user` field in `MeasurementSpec.Duration`.

See #159 and #160