### PR TITLE
Add custom methodology with variance field

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
@@ -22,6 +22,12 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DirectComputationProto";
 
+// Information about the custom direct methodology.
+message CustomDirectMethodology {
+  // The variance of the result computed with the custom direct methodology.
+  double variance = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
 // Parameters used when applying the deterministic count distinct methodology.
 message DeterministicCountDistinct {}
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -130,23 +130,27 @@ message Measurement {
 
       // The mechanism used to generate noise during computation.
       //
-      // While this **should** always be set, if it is not then it implies
-      // `CONTINUOUS_LAPLACE`.
-      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
-      // changes.
+      // During the transition of adopting this field, this field may not be
+      // specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       ProtocolConfig.NoiseMechanism noise_mechanism = 2;
 
       // The computation methodology done by data provider.
       //
-      // Currently, only direct measurement would populate it. Before all EDPs
-      // incorporate the new API, if no methodology is set for the direct reach
-      // result, it is assumed that DeterministicCountDistinct is used.
+      // Currently, only direct measurement would populate it. During the
+      // transition of adopting this field, this field may not be specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       oneof methodology {
+        // Custom methodology.
+        CustomDirectMethodology custom_direct_methodology = 3;
+
         // Deterministic count distinct methodology.
-        DeterministicCountDistinct deterministic_count_distinct = 3;
+        DeterministicCountDistinct deterministic_count_distinct = 4;
 
         // Liquid Legions count distinct methodology.
-        LiquidLegionsCountDistinct liquid_legions_count_distinct = 4;
+        LiquidLegionsCountDistinct liquid_legions_count_distinct = 5;
       }
     }
     // The reach result.
@@ -162,23 +166,27 @@ message Measurement {
 
       // The mechanism used to generate noise during computation.
       //
-      // While this **should** always be set, if it is not then it implies
-      // `CONTINUOUS_LAPLACE`.
-      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
-      // changes.
+      // During the transition of adopting this field, this field may not be
+      // specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       ProtocolConfig.NoiseMechanism noise_mechanism = 2;
 
       // The computation methodology done by data provider.
       //
-      // Currently, only direct measurement would populate it. Before all EDPs
-      // incorporate the new API, if no methodology is set for the direct
-      // frequency result, it is assumed that DeterministicDistribution is used.
+      // Currently, only direct measurement would populate it. During the
+      // transition of adopting this field, this field may not be specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       oneof methodology {
+        // Custom methodology.
+        CustomDirectMethodology custom_direct_methodology = 3;
+
         // Deterministic distribution methodology.
-        DeterministicDistribution deterministic_distribution = 3;
+        DeterministicDistribution deterministic_distribution = 4;
 
         // Liquid Legions distribution methodology.
-        LiquidLegionsDistribution liquid_legions_distribution = 4;
+        LiquidLegionsDistribution liquid_legions_distribution = 5;
       }
     }
     // The frequency result.
@@ -191,20 +199,24 @@ message Measurement {
 
       // The mechanism used to generate noise during computation.
       //
-      // While this **should** always be set, if it is not then it implies
-      // `CONTINUOUS_LAPLACE`.
-      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
-      // changes.
+      // During the transition of adopting this field, this field may not be
+      // specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       ProtocolConfig.NoiseMechanism noise_mechanism = 2;
 
       // The computation methodology done by data provider.
       //
-      // Currently, only direct measurement would populate it. Before all EDPs
-      // incorporate the new API, if no methodology is set for the impression
-      // result, it is assumed that DeterministicCount is used.
+      // Currently, only direct measurement would populate it. During the
+      // transition of adopting this field, this field may not be specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       oneof methodology {
+        // Custom methodology.
+        CustomDirectMethodology custom_direct_methodology = 3;
+
         // Deterministic count methodology.
-        DeterministicCount deterministic_count = 3;
+        DeterministicCount deterministic_count = 4;
       }
     }
     // The impression result.
@@ -217,20 +229,24 @@ message Measurement {
 
       // The mechanism used to generate noise during computation.
       //
-      // While this **should** always be set, if it is not then it implies
-      // `CONTINUOUS_LAPLACE`.
-      // (-- TODO(@riemanli): set required once EDPs incorporate the new API --)
-      // changes.
+      // During the transition of adopting this field, this field may not be
+      // specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       ProtocolConfig.NoiseMechanism noise_mechanism = 2;
 
       // The computation methodology done by data provider.
       //
-      // Currently, only direct measurement would populate it. Before all EDPs
-      // incorporate the new API, if no methodology is set for the watch
-      // duration result, it is assumed that DeterministicSum is used.
+      // Currently, only direct measurement would populate it. During the
+      // transition of adopting this field, this field may not be specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       oneof methodology {
+        // Custom methodology.
+        CustomDirectMethodology custom_direct_methodology = 3;
+
         // Deterministic sum methodology.
-        DeterministicSum deterministic_sum = 3;
+        DeterministicSum deterministic_sum = 4;
       }
     }
     // The watch duration result.
@@ -241,11 +257,15 @@ message Measurement {
       // The population value.
       int64 value = 1;
 
-      // The computation methodology done by data provider. Currently, only
-      // direct measurement would populate it.
+      // The computation methodology done by data provider.
+      //
+      // Currently, only direct measurement would populate it. During the
+      // transition of adopting this field, this field may not be specified.
+      // (-- TODO(@riemanli): set required for new fulfillment once EDPs
+      // incorporate the new API changes. --)
       oneof methodology {
         // Deterministic count methodology.
-        DeterministicCount deterministic_count = 3;
+        DeterministicCount deterministic_count = 2;
       }
     }
     // The population result.

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -109,6 +109,8 @@ message ProtocolConfig {
   // The `DataProvider` may choose from the specified noise mechanisms and
   // methodologies.
   message Direct {
+    // Configuration parameters for custom direct methodology.
+    message CustomDirectMethodology {}
     // Configuration parameters for the deterministic count distinct
     // methodology.
     message DeterministicCountDistinct {}
@@ -135,35 +137,41 @@ message ProtocolConfig {
     // Only continuous types and NONE are allowed.
     repeated NoiseMechanism noise_mechanisms = 1;
 
+    // Custom direct methodology.
+    //
+    // Used when data provider wants to use a methodology that is not listed in
+    // protocol config to compute direct measurements.
+    CustomDirectMethodology custom_direct_methodology = 2;
+
     // Deterministic count distinct methodology.
     //
     // Can be used in reach computations.
-    DeterministicCountDistinct deterministic_count_distinct = 2;
+    DeterministicCountDistinct deterministic_count_distinct = 3;
 
     // Deterministic distribution methodology.
     //
     // Can be used in frequency computations.
-    DeterministicDistribution deterministic_distribution = 3;
+    DeterministicDistribution deterministic_distribution = 4;
 
     // Deterministic count methodology.
     //
     // Can be used in impression and population computations.
-    DeterministicCount deterministic_count = 4;
+    DeterministicCount deterministic_count = 5;
 
     // Deterministic sum methodology.
     //
     // Can be used in watch duration computations.
-    DeterministicSum deterministic_sum = 5;
+    DeterministicSum deterministic_sum = 6;
 
     // Liquid Legions count distinct methodology.
     //
     // Can be used in reach computations.
-    LiquidLegionsCountDistinct liquid_legions_count_distinct = 6;
+    LiquidLegionsCountDistinct liquid_legions_count_distinct = 7;
 
     // Liquid Legions distribution methodology.
     //
     // Can be used in frequency computations.
-    LiquidLegionsDistribution liquid_legions_distribution = 7;
+    LiquidLegionsDistribution liquid_legions_distribution = 8;
   }
 
   // Configuration for the Reach-Only Liquid Legions v2 protocol.


### PR DESCRIPTION
Adding a custom type of methodology for the following reasons:
1. The data provider may want to execute measurement computations with their own methods which are not listed in the protocol config.
2. For existing direct measurements to which no methodology is attached, using `CustomMethodology` indicates the unknown of the computation details. 

In addition, remove using `CONTINUOUS_LAPLACE` as the default of an unspecified direct noise mechanism.