### PR TITLE
Remove NONE from ProtocolConfig.NoiseMechanism

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -61,10 +61,10 @@ message ProtocolConfig {
   //
   // (-- TODO(@riemanli): Move the noise mechanism to its own file. --)
   enum NoiseMechanism {
+    reserved 3;
+
     // Default value used if the mechanism is omitted.
     NOISE_MECHANISM_UNSPECIFIED = 0;
-    // No noise is added.
-    NONE = 3;
     // Geometric, i.e. discrete Laplace.
     GEOMETRIC = 1;
     // Discrete Gaussian.


### PR DESCRIPTION
`NONE` noise mechanism was prepared for `Population` measurements. However, the decision ended up not even having noise mechanism field in `Population` result, and so `NONE` noise mechanism is not needed anymore. Furthermore, the existence of `NONE` noise mechanism allows EDPs not adding DP noise to the measurement results, which is not privacy safe. 