### PR TITLE
Refactor custom direct methodology

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
@@ -24,8 +24,31 @@ option java_outer_classname = "DirectComputationProto";
 
 // Information about the custom direct methodology.
 message CustomDirectMethodology {
-  // The variance of the result computed with the custom direct methodology.
-  double variance = 1 [(google.api.field_behavior) = REQUIRED];
+  // Different types of variances of a frequency distribution result.
+  message FrequencyVariances {
+    // The variances of a frequency distribution from frequency 1 to maximum
+    // frequency specified in the measurement spec.
+    map<int64, double> variances = 1 [(google.api.field_behavior) = REQUIRED];
+    // The variances of a k+ frequency distribution from frequency 1 to
+    // maximum frequency specified in the measurement spec.
+    //
+    // A K+ frequency distribution is derived from the frequency distribution by
+    // calculating the reach ratio of frequency K and above, i.e. reversed
+    // cumulative sum of the frequency distribution. For example, a frequency
+    // distribution {1: 0.4, 2: 0.3, 3: 0.2, 4:0.1, 5: 0.0} will have a K+
+    // frequency distribution {1: 1.0, 2: 0.6, 3: 0.3, 4:0.1, 5: 0.0}.
+    map<int64, double> k_plus_variances = 2
+        [(google.api.field_behavior) = REQUIRED];
+  }
+
+  // The variance of the result computed from the custom direct methodology.
+  // REQUIRED.
+  oneof variance {
+    // The variance when the result is a scalar type.
+    double scalar = 1;
+    // The variance when the result is a frequency type.
+    FrequencyVariances frequency = 2;
+  }
 }
 
 // Parameters used when applying the deterministic count distinct methodology.

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -140,7 +140,11 @@ message ProtocolConfig {
     // Custom direct methodology.
     //
     // Used when data provider wants to use a methodology that is not listed in
-    // protocol config to compute direct measurements.
+    // direct protocol config to compute direct measurements. Data providers who
+    // use any custom direct methodology must guarantee the independence of the
+    // result by generating a random seed that is unique for the particular
+    // measurement and seeding their hash function with it. This guidance only
+    // applies to direct measurements, not MPC measurements.
     CustomDirectMethodology custom_direct_methodology = 2;
 
     // Deterministic count distinct methodology.


### PR DESCRIPTION
## TL;DR
This pull request introduces changes to the `direct_computation.proto` and `protocol_config.proto` files. The changes include the addition of a new message `FrequencyVariances` and a `oneof` field `variance` in the `CustomDirectMethodology` message. It also modifies the comment for `custom_direct_methodology` in `ProtocolConfig`.
> 
## What changed
In `direct_computation.proto`, the `variance` field in `CustomDirectMethodology` has been replaced with a `oneof` field that can either be a `scalar` or `FrequencyVariances`. The `FrequencyVariances` message includes two maps for `variances` and `k_plus_variances`, which represent the variances of different types of frequency distributions from frequency 1 to the maximum frequency specified in the measurement spec.

> 
In `protocol_config.proto`, the comment for `custom_direct_methodology` has been updated to include a requirement for data providers to guarantee the independence of the result by salting their hash functions.
> 
## Why make this change
This change allows for more flexibility in specifying the variance in the `CustomDirectMethodology` message. It also clarifies the requirements for data providers who choose to use a custom direct methodology.