### PR TITLE
Add missing patterns for ExchangeStepAttempt.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
@@ -29,6 +29,8 @@ message ExchangeStepAttempt {
   option (google.api.resource) = {
     type: "halo.wfanet.org/ExchangeStepAttempt"
     pattern: "recurringExchanges/{recurring_exchange}/exchanges/{exchange}/steps/{exchange_step}/attempts/{exchange_step_attempt}"
+    pattern: "dataProviders/{data_provider}/recurringExchanges/{recurring_exchange}/exchanges/{exchange}/steps/{exchange_step}/attempts/{exchange_step_attempt}"
+    pattern: "modelProviders/{data_provider}/recurringExchanges/{recurring_exchange}/exchanges/{exchange}/steps/{exchange_step}/attempts/{exchange_step_attempt}"
     singular: "exchangeStepAttempt"
     plural: "exchangeStepAttempts"
   };


### PR DESCRIPTION
The recurringExchanges resource collection has multiple patterns, so all of its descendents must also support those patterns.