### PR TITLE
Change type of exchange_workflow field in RecurringExchange.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -46,7 +46,7 @@ message ExchangeStep {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // Current index of the step inside the serialized_exchange_workflow.
+  // Current index of the step inside `exchange_workflow`.
   int32 step_index = 5 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
@@ -68,9 +68,9 @@ message ExchangeStep {
     ];
   }
 
-  // Serialized denormalized `exchange_workflow` field from the ancestor
+  // Denormalized `exchange_workflow` field from the ancestor
   // `RecurringExchange`.
-  bytes serialized_exchange_workflow = 3 [
+  bytes exchange_workflow = 3 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = IMMUTABLE
   ];

--- a/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
@@ -41,8 +41,8 @@ message RecurringExchange {
   // Resource name.
   string name = 1;
 
-  // The ExchangeWorkflow for this recurring exchange.
-  ExchangeWorkflow exchange_workflow = 2 [
+  // Serialized `ExchangeWorkflow` for this `RecurringExchange`.
+  bytes exchange_workflow = 2 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];


### PR DESCRIPTION
This resource type is not used by any service so this is a safe change.

Closes #182