### PR TITLE
Make CustomDirectMethodology.variance not required

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
@@ -24,31 +24,58 @@ option java_outer_classname = "DirectComputationProto";
 
 // Information about the custom direct methodology.
 message CustomDirectMethodology {
-  // Different types of variances of a frequency distribution result.
-  message FrequencyVariances {
-    // The variances of a frequency distribution from frequency 1 to maximum
-    // frequency specified in the measurement spec.
-    map<int64, double> variances = 1 [(google.api.field_behavior) = REQUIRED];
-    // The variances of a k+ frequency distribution from frequency 1 to
-    // maximum frequency specified in the measurement spec.
-    //
-    // A K+ frequency distribution is derived from the frequency distribution by
-    // calculating the reach ratio of frequency K and above, i.e. reversed
-    // cumulative sum of the frequency distribution. For example, a frequency
-    // distribution {1: 0.4, 2: 0.3, 3: 0.2, 4:0.1, 5: 0.0} will have a K+
-    // frequency distribution {1: 1.0, 2: 0.6, 3: 0.3, 4:0.1, 5: 0.0}.
-    map<int64, double> k_plus_variances = 2
-        [(google.api.field_behavior) = REQUIRED];
+  // The information about a variance.
+  message Variance {
+    // Different types of variances of a frequency distribution result.
+    message FrequencyVariances {
+      // The variances of a frequency distribution from frequency 1 to maximum
+      // frequency specified in the measurement spec.
+      map<int64, double> variances = 1 [(google.api.field_behavior) = REQUIRED];
+      // The variances of a k+ frequency distribution from frequency 1 to
+      // maximum frequency specified in the measurement spec.
+      //
+      // A K+ frequency distribution is derived from the frequency distribution
+      // by calculating the reach ratio of frequency K and above, i.e. reversed
+      // cumulative sum of the frequency distribution. For example, a frequency
+      // distribution {1: 0.4, 2: 0.3, 3: 0.2, 4:0.1, 5: 0.0} will have a K+
+      // frequency distribution {1: 1.0, 2: 0.6, 3: 0.3, 4:0.1, 5: 0.0}.
+      map<int64, double> k_plus_variances = 2
+          [(google.api.field_behavior) = REQUIRED];
+    }
+
+    // Information about lack of variance.
+    message Unavailable {
+      // Reason for a `Unavailable`.
+      enum Reason {
+        // Default value used if the reason is omitted.
+        //
+        // Used to capture unset reason which is invalid. This enum constant
+        // should never be set.
+        REASON_UNSPECIFIED = 0;
+        // When the variance is mathematically not derivable from a custom
+        // direct methodology.
+        UNDERIVABLE = 1;
+        // When the variance is obtained by upstream providers and not
+        // accessible.
+        INACCESSIBLE = 2;
+      }
+      // Reason for this `Unavailable`.
+      Reason reason = 1 [(google.api.field_behavior) = REQUIRED];
+    }
+
+    // The type of variance associated with a result. Required.
+    oneof type {
+      // The variance when the computation result is a scalar type.
+      double scalar = 1;
+      // The variance when the computation result is a frequency type.
+      FrequencyVariances frequency = 2;
+      // The variance is unavailable for a custom direct methodology.
+      Unavailable unavailable = 3;
+    }
   }
 
-  // The variance of the result computed from the custom direct methodology.
-  // REQUIRED.
-  oneof variance {
-    // The variance when the result is a scalar type.
-    double scalar = 1;
-    // The variance when the result is a frequency type.
-    FrequencyVariances frequency = 2;
-  }
+  // The variance of the result computed from this custom direct methodology.
+  Variance variance = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Parameters used when applying the deterministic count distinct methodology.


### PR DESCRIPTION
TV measurements will not have variances, so the Kingdom API needs to allow that by either
1. allowing the data provider not indicating the variance of their direct measurement, i.e. `variance` is not required,
2. use `NaN` value in `scalar` or `frequency`, or
3. adding a new type `Unknown` under `variance`.

This PR proposed to use option 1.