### PR TITLE
Drop signatures for public key fields where not needed.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -65,6 +65,7 @@ proto_library(
         ":protocol_config_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:any_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -37,7 +37,7 @@ message EventGroup {
     plural: "eventGroups"
   };
 
-  reserved 8;
+  reserved 3, 4, 8;
 
   // Resource name.
   //
@@ -52,23 +52,6 @@ message EventGroup {
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];
-
-  // Resource name of the `Certificate` belonging to `measurement_consumer`.
-  // Must be set if `measurement_consumer_public_key` is set.
-  string measurement_consumer_certificate = 3
-      [(google.api.resource_reference).type = "halo.wfanet.org/Certificate"];
-
-  // Pre-shared serialized `EncryptionPublicKey`, which can be verified using
-  // `measurement_consumer_certificate`. Must be set if `encrypted_metadata` is
-  // set.
-  //
-  // The version of the `EncryptionPublicKey` message must match the API version
-  // used to last update this resource.
-  //
-  // (-- TODO(@SanjayVas): Include the `message` directly rather than
-  // wrapping it in a `SignedMessage`. The signature is not needed here, as
-  // the `DataProvider` should have already verified it. --)
-  SignedMessage measurement_consumer_public_key = 4;
 
   // ID referencing the `EventGroup` in an external system, provided by the
   // `DataProvider`.
@@ -113,6 +96,13 @@ message EventGroup {
   // The version of the `Metadata` message type must match the API version used
   // to last update this resource.
   EncryptedMessage encrypted_metadata = 10;
+
+  // Pre-shared packed `EncryptionPublicKey` Must be set if `encrypted_metadata`
+  // is set.
+  //
+  // The version of the `EncryptionPublicKey` message must match the API version
+  // used to last update this resource.
+  google.protobuf.Any measurement_consumer_public_key = 12;
 
   // Possible states of Event Group.
   enum State {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -18,6 +18,7 @@ package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/direct_computation.proto";
@@ -68,24 +69,24 @@ message Measurement {
 
     // Value of a map entry.
     message Value {
-      reserved 3;
+      reserved 2, 3;
 
       // Resource name of the `Certificate` belonging to `data_provider`.
+      //
+      // (--
+      // TODO(world-federation-of-advertisers/cross-media-measurement-api#188):
+      // Remove this once the certificate is always specified in
+      // `FulfillDirectRequisitionRequest`. --)
       string data_provider_certificate = 1 [
         (google.api.resource_reference).type = "halo.wfanet.org/Certificate",
         (google.api.field_behavior) = REQUIRED
       ];
 
-      // Pre-shared serialized `EncryptionPublicKey`, which can be verified
-      // using `data_provider_certificate`.
+      // Pre-shared packed `EncryptionPublicKey`.
       //
       // The version of the `EncryptionPublicKey` message type must correspond
       // to the API version that this resource was created in.
-      //
-      // (-- TODO(@SanjayVas): Include the `message` directly rather than
-      // wrapping it in a `SignedMessage`. The signature is not needed here, as
-      // the `MeasurementConsumer` should have already verified it. --)
-      SignedMessage data_provider_public_key = 2
+      google.protobuf.Any data_provider_public_key = 6
           [(google.api.field_behavior) = REQUIRED];
 
       // Encrypted `SignedMessage` containing the serialized `RequisitionSpec`

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -18,6 +18,7 @@ package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/any.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/measurement.proto";
 import "wfa/measurement/api/v2alpha/protocol_config.proto";
@@ -75,6 +76,11 @@ message Requisition {
 
   // Denormalized `data_provider_certificate` field from the corresponding
   // `DataProviderEntry` in `measurement`.
+  //
+  // (--
+  // TODO(world-federation-of-advertisers/cross-media-measurement-api#188):
+  // Remove this once the certificate is always specified in
+  // `FulfillDirectRequisitionRequest`. --)
   string data_provider_certificate = 6 [
     (google.api.resource_reference).type = "halo.wfanet.org/Certificate",
     (google.api.field_behavior) = OUTPUT_ONLY,
@@ -83,10 +89,18 @@ message Requisition {
 
   // Denormalized `data_provider_public_key` field from the corresponding
   // `DataProviderEntry` in `measurement`.
-  SignedMessage data_provider_public_key = 7 [
+  google.protobuf.Any data_provider_public_key = 15 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = IMMUTABLE
   ];
+
+  // Denormalized `data_provider_public_key` field with signature from the
+  // corresponding `DataProviderEntry` in `measurement`.
+  //
+  // Deprecated: The `Measurement` may not have signature for this key. Use
+  // `data_provider_public_key` instead.
+  SignedMessage signed_data_provider_public_key = 7
+      [(google.api.field_behavior) = OUTPUT_ONLY, deprecated = true];
 
   // Denormalized `encrypted_requisition_spec` field from the corresponding
   // `DataProviderEntry` in `measurement`.


### PR DESCRIPTION
This is a breaking API change, but attempts to maintain wire-compatibility for EDP Requisition fulfillment.