### PR TITLE
Update FulfillRequisitionRequest and ProtocolConfig for ShuffleBasedSecretSharing protocol

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -496,6 +496,7 @@ proto_library(
     srcs = ["requisition_fulfillment_service.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":protocol_config_proto",
         ":requisition_proto",
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -285,7 +285,9 @@ message ShareShuffleSketchParams {
   // The number of registers in the sketch.
   int64 register_count = 1;
 
-  // Length of each item in bytes. #_EDPs * max_frequency should be no more than
-  // 2^(bytes_per_item*8).
-  int32 bytes_per_item = 2;
+  // Length of each register in bytes.
+  //
+  // The product of `maximum_frequency` and the `nonce_hashes` count from the
+  // `MeasurementSpec` should be no more than 2 ^ (`bytes_per_register` * 8).
+  int32 bytes_per_register = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -201,6 +201,18 @@ message ProtocolConfig {
     NoiseMechanism noise_mechanism = 4;
   }
 
+  // Configuration for the Shuffle Based Secret Sharing Protocol.
+  message ShuffleBasedSecretSharing {
+    // Parameters for secret sharing sketches.
+    SecretSharingSketchParams sketch_params = 1
+        [(google.api.field_behavior) = REQUIRED];
+    // The maximum frequency to reveal in the histogram. This is also the EDP
+    // frequency cap.
+    int32 maximum_frequency = 2;
+    // The mechanism to generate noise by workers during the computation.
+    NoiseMechanism noise_mechanism = 3;
+  }
+
   // Configuration for a specific protocol.
   message Protocol {
     // Configuration for the specific protocol.
@@ -224,6 +236,11 @@ message ProtocolConfig {
       // using this protocol can be fulfilled by calling
       // RequisitionFulfillment/FulfillRequisition with an encrypted sketch.
       ReachOnlyLiquidLegionsV2 reach_only_liquid_legions_v2 = 3;
+
+      // Shuffle Based Secret Sharing protocol.
+      //
+      // Using honest-majority setting.
+      ShuffleBasedSecretSharing shuffle_based_secret_sharing = 4;
     }
   }
 
@@ -263,4 +280,13 @@ message ReachOnlyLiquidLegionsSketchParams {
 
   // The maximum size of the Liquid Legions sketch.
   int64 max_size = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Parameters for a Shuffle Based Secret Sharing sketch.
+message SecretSharingSketchParams {
+  // The size of the sketch.
+  int64 sketch_size = 1;
+  // Length of each item in bits. #_EDPs * max_frequency should be no more than
+  // 2^bit_per_item.
+  int32 bit_per_item = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -206,11 +206,9 @@ message ProtocolConfig {
     // Parameters for secret sharing sketches.
     SecretSharingSketchParams sketch_params = 1
         [(google.api.field_behavior) = REQUIRED];
-    // The maximum frequency to reveal in the histogram. This is also the EDP
-    // frequency cap.
-    int32 maximum_frequency = 2;
+
     // The mechanism to generate noise by workers during the computation.
-    NoiseMechanism noise_mechanism = 3;
+    NoiseMechanism noise_mechanism = 2;
   }
 
   // Configuration for a specific protocol.
@@ -286,6 +284,7 @@ message ReachOnlyLiquidLegionsSketchParams {
 message SecretSharingSketchParams {
   // The size of the sketch.
   int64 sketch_size = 1;
+
   // Length of each item in bits. #_EDPs * max_frequency should be no more than
   // 2^bit_per_item.
   int32 bit_per_item = 2;

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -201,10 +201,11 @@ message ProtocolConfig {
     NoiseMechanism noise_mechanism = 4;
   }
 
-  // Configuration for the Shuffle Based Secret Sharing Protocol.
-  message ShuffleBasedSecretSharing {
-    // Parameters for secret sharing sketches.
-    SecretSharingSketchParams sketch_params = 1
+  // Configuration for the Honest Majority Shuffle Based Secret Sharing
+  // Protocol.
+  message HonestMajorityShareShuffle {
+    // Parameters for honest majority shuffle sketches.
+    ShareShuffleSketchParams sketch_params = 1
         [(google.api.field_behavior) = REQUIRED];
 
     // The mechanism to generate noise by workers during the computation.
@@ -235,10 +236,8 @@ message ProtocolConfig {
       // RequisitionFulfillment/FulfillRequisition with an encrypted sketch.
       ReachOnlyLiquidLegionsV2 reach_only_liquid_legions_v2 = 3;
 
-      // Shuffle Based Secret Sharing protocol.
-      //
-      // Using honest-majority setting.
-      ShuffleBasedSecretSharing shuffle_based_secret_sharing = 4;
+      // Honest Majority Shuffle Based Secret Sharing protocol.
+      HonestMajorityShareShuffle honest_majority_share_shuffle = 4;
     }
   }
 
@@ -280,8 +279,9 @@ message ReachOnlyLiquidLegionsSketchParams {
   int64 max_size = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// Parameters for a Shuffle Based Secret Sharing sketch.
-message SecretSharingSketchParams {
+// Sketch parameters for a Honest Majority Shuffle Based Secret Sharing
+// protocol.
+message ShareShuffleSketchParams {
   // The number of registers in the sketch.
   int64 register_count = 1;
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -282,10 +282,10 @@ message ReachOnlyLiquidLegionsSketchParams {
 
 // Parameters for a Shuffle Based Secret Sharing sketch.
 message SecretSharingSketchParams {
-  // The size of the sketch.
-  int64 sketch_size = 1;
+  // The number of registers in the sketch.
+  int64 register_count = 1;
 
-  // Length of each item in bits. #_EDPs * max_frequency should be no more than
-  // 2^bit_per_item.
-  int32 bit_per_item = 2;
+  // Length of each item in bytes. #_EDPs * max_frequency should be no more than
+  // 2^(byte_per_item*8).
+  int32 byte_per_item = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -286,6 +286,6 @@ message ShareShuffleSketchParams {
   int64 register_count = 1;
 
   // Length of each item in bytes. #_EDPs * max_frequency should be no more than
-  // 2^(byte_per_item*8).
-  int32 byte_per_item = 2;
+  // 2^(bytes_per_item*8).
+  int32 bytes_per_item = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -18,6 +18,7 @@ package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "wfa/measurement/api/v2alpha/protocol_config.proto";
 import "wfa/measurement/api/v2alpha/requisition.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -56,6 +57,11 @@ message FulfillRequisitionRequest {
     //     aip.dev/not-precedent: This is a random 64-bit value. --)
     fixed64 nonce = 3 [(google.api.field_behavior) = REQUIRED];
 
+    // The protocol config of the Computation. This is used to validate that
+    // EDPs and the MPC are using the same protocol config.
+    // Required for ShuffleBasedSecretSharing protocol.
+    ProtocolConfig protocol_config = 4;
+
     // Requisitions of ShuffleBasedSecretSharing protocol is fulfilled by either
     // a blob or a seed.
     message ShuffleBasedSecretSharing {
@@ -66,7 +72,7 @@ message FulfillRequisitionRequest {
     oneof protocol {
       // Shuffle based secret sharing protocol. Fulfilled by either chunks (a
       // blob), or a seed.
-      ShuffleBasedSecretSharing shuffle_based_secret_sharing = 4;
+      ShuffleBasedSecretSharing shuffle_based_secret_sharing = 5;
     }
   }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -60,8 +60,8 @@ message FulfillRequisitionRequest {
     // The protocol config of the Computation. This is used to validate that
     // EDPs and the MPC are using the same protocol config.
     //
-    // Required for HonestMajorityShareShuffle protocol. LiquidLegionsV2
-    // protocols will require this field in the future.
+    // Required for HonestMajorityShareShuffle protocol. All protocols will
+    // require this field in the future.
     ProtocolConfig protocol_config = 4;
 
     // Protocol specified values for HonestMajorityShareShuffle.
@@ -69,8 +69,8 @@ message FulfillRequisitionRequest {
     // A Requisition of HonestMajorityShareShuffle protocol is fulfilled by
     // either a seed or a blob of `BodyChunk`s.
     message HonestMajorityShareShuffle {
-      // The seed is sampled by the DataProvider and can be expanded into a
-      // deterministic blob using the same PRNG function.
+      // A random seed which is sampled by the DataProvider and can be expanded
+      // into a deterministic blob using the same PRNG function.
       //
       // If the seed is not specified, it means the requisition is
       // fulfilled by a blob of `BodyChunk`s.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -59,10 +59,13 @@ message FulfillRequisitionRequest {
     // Requisitions of ShuffleBasedSecretSharing protocol is fulfilled by either
     // a blob or a seed.
     message ShuffleBasedSecretSharing {
+      // The seed can be expanded into a deterministic blob using the same PRNG.
       bytes seed = 1;
     }
     // Protocol specified values.
     oneof protocol {
+      // Shuffle based secret sharing protocol. Fulfilled by either chunks (a
+      // blob), or a seed.
       ShuffleBasedSecretSharing shuffle_based_secret_sharing = 4;
     }
   }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -59,12 +59,13 @@ message FulfillRequisitionRequest {
 
     // The protocol config of the Computation. This is used to validate that
     // EDPs and the MPC are using the same protocol config.
-    // NOT required for LiquidLegionV2 protocol.
+    //
+    // NOT required for LiquidLegionV2 protocols.
     ProtocolConfig protocol_config = 4;
 
-    // Requisitions of ShuffleBasedSecretSharing protocol is fulfilled by either
-    // a blob or a seed.
-    message ShuffleBasedSecretSharing {
+    // Requisitions of HonestMajorityShareShuffle protocol is fulfilled by
+    // either a blob or a seed.
+    message HonestMajorityShareShuffle {
       // The seed can be expanded into a deterministic blob using the same PRNG.
       //
       // If the seed is not specified or empty, it means the requisition is
@@ -73,9 +74,9 @@ message FulfillRequisitionRequest {
     }
     // Protocol specified values.
     oneof protocol {
-      // Shuffle based secret sharing protocol. Fulfilled by either chunks (a
-      // blob), or a seed.
-      ShuffleBasedSecretSharing shuffle_based_secret_sharing = 5;
+      // Honest Majority Shuffle based secret sharing protocol. Fulfilled by
+      // either chunks (a blob), or a seed.
+      HonestMajorityShareShuffle honest_majority_share_shuffle = 5;
     }
   }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -55,6 +55,16 @@ message FulfillRequisitionRequest {
     // (-- api-linter: core::0141::forbidden-types=disabled
     //     aip.dev/not-precedent: This is a random 64-bit value. --)
     fixed64 nonce = 3 [(google.api.field_behavior) = REQUIRED];
+
+    // Requisitions of ShuffleBasedSecretSharing protocol is fulfilled by either
+    // a blob or a seed.
+    message ShuffleBasedSecretSharing {
+      bytes seed = 1;
+    }
+    // Protocol specified values.
+    oneof protocol {
+      ShuffleBasedSecretSharing shuffle_based_secret_sharing = 4;
+    }
   }
 
   // The chunk message for this streaming request.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -59,13 +59,16 @@ message FulfillRequisitionRequest {
 
     // The protocol config of the Computation. This is used to validate that
     // EDPs and the MPC are using the same protocol config.
-    // Required for ShuffleBasedSecretSharing protocol.
+    // NOT required for LiquidLegionV2 protocol.
     ProtocolConfig protocol_config = 4;
 
     // Requisitions of ShuffleBasedSecretSharing protocol is fulfilled by either
     // a blob or a seed.
     message ShuffleBasedSecretSharing {
       // The seed can be expanded into a deterministic blob using the same PRNG.
+      //
+      // If the seed is not specified or empty, it means the requisition is
+      // fulfilled by a blob of chunks.
       bytes seed = 1;
     }
     // Protocol specified values.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -60,16 +60,20 @@ message FulfillRequisitionRequest {
     // The protocol config of the Computation. This is used to validate that
     // EDPs and the MPC are using the same protocol config.
     //
-    // NOT required for LiquidLegionV2 protocols.
+    // Required for HonestMajorityShareShuffle protocol. LiquidLegionsV2
+    // protocols will require this field in the future.
     ProtocolConfig protocol_config = 4;
 
-    // Requisitions of HonestMajorityShareShuffle protocol is fulfilled by
-    // either a blob or a seed.
+    // Protocol specified values for HonestMajorityShareShuffle.
+    //
+    // A Requisition of HonestMajorityShareShuffle protocol is fulfilled by
+    // either a seed or a blob of `BodyChunk`s.
     message HonestMajorityShareShuffle {
-      // The seed can be expanded into a deterministic blob using the same PRNG.
+      // The seed is sampled by the DataProvider and can be expanded into a
+      // deterministic blob using the same PRNG function.
       //
-      // If the seed is not specified or empty, it means the requisition is
-      // fulfilled by a blob of chunks.
+      // If the seed is not specified, it means the requisition is
+      // fulfilled by a blob of `BodyChunk`s.
       bytes seed = 1;
     }
     // Protocol specified values.
@@ -84,12 +88,19 @@ message FulfillRequisitionRequest {
   message BodyChunk {
     // The portion of the data for this `BodyChunk`.
     //
-    // The format of the data depends on the corresponding `MeasurementSpec`. If
-    // the `Requisition` is for an encrypted sketch, this is the register
-    // data as documented in the `Sketch` message (sketch.proto) encrypted using
-    // the combined `Duchy` ElGamal public keys. The only alignment requirement
-    // is by bytes: a chunk might begin or end in the middle of a single
-    // register.
+    // The format of the data depends on the corresponding `MeasurementSpec` and
+    // `ProtocolConfig`.
+    //
+    // If the `Requisition` is for an encrypted sketch for LiquidLegionV2
+    // protocols, this is the register data as documented in the `Sketch`
+    // message (sketch.proto) encrypted using the combined `Duchy` ElGamal
+    // public keys.
+    //
+    // If the `Requisition` is a sketch for HonestMajorityShareShuffle protocol,
+    // this is an array of counts as registers.
+    //
+    // The only alignment requirement is by bytes: a chunk might begin or end in
+    // the middle of a single register.
     //
     // The optimal size of this field is one that would result in the
     // `FulfillRequisitionRequest` message being between 16KiB and 64KiB.


### PR DESCRIPTION
For shuffle based secret sharing protocol, requisitions are fulfilled by EDPs with either chunks of data (a blob) or a seed. The seed can be expanded into a deterministic blob with the same PRNG by workers.
The change is back-compatible.

Also added ProtocolConfig in FulfillRequisitionRequest for this issue(https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/1329).
