### PR TITLE
Add Population params for Population message in measurement spec

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -118,7 +118,13 @@ message MeasurementSpec {
   }
 
   // Parameters for a population measurement.
-  message Population {}
+  message Population {
+    // Differential privacy parameters.
+    DifferentialPrivacyParams privacy_params = 1;
+
+    // Total population for this measurement.
+    int32 population_count = 2;
+  }
 
   // Fields specific to the type of measurement.
   oneof measurement_type {


### PR DESCRIPTION
.Add Population params for Population message in measurement spec to be used in Reporting API in cross-media-measurement.