### PR TITLE
Add data_provider_certificate into HMSS requisition fulfillment.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -76,6 +76,14 @@ message FulfillRequisitionRequest {
       // worker's public key in
       // Requisition.DuchyEntry.HonestMajorityShareShuffle.
       EncryptedMessage secret_seed = 1;
+
+      // Resource name of the `Certificate` belonging to the parent
+      // `DataProvider` used to verify the secret_seed signature.
+      string data_provider_certificate = 2 [
+        (google.api.resource_reference).type = "halo.wfanet.org/Certificate",
+        (google.api.field_behavior) = OUTPUT_ONLY,
+        (google.api.field_behavior) = IMMUTABLE
+      ];
     }
 
     // Protocol specified values.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -81,8 +81,7 @@ message FulfillRequisitionRequest {
       // `DataProvider` used to verify the secret_seed signature.
       string data_provider_certificate = 2 [
         (google.api.resource_reference).type = "halo.wfanet.org/Certificate",
-        (google.api.field_behavior) = OUTPUT_ONLY,
-        (google.api.field_behavior) = IMMUTABLE
+        (google.api.field_behavior) = REQUIRED
       ];
     }
 


### PR DESCRIPTION
Duchy needs the certificate specified by the EDP to verify the signature of secret seed.