### PR TITLE
Add register_count into HMSS requisition fulfillment header.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -287,12 +287,15 @@ message ReachOnlyLiquidLegionsSketchParams {
 // Sketch parameters for a Honest Majority Shuffle Based Secret Sharing
 // protocol.
 message ShareShuffleSketchParams {
-  // The number of registers in the sketch.
-  int64 register_count = 1;
+  reserved 1;
 
   // Length of each register in bytes.
   //
   // The product of `maximum_frequency` and the `nonce_hashes` count from the
   // `MeasurementSpec` should be no more than 2 ^ (`bytes_per_register` * 8).
   int32 bytes_per_register = 2;
+
+  // The modulus used in the protocol. It is required to be greater than
+  // (1 + `maximum_frequency`).
+  int32 ring_modulus = 3;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -287,15 +287,13 @@ message ReachOnlyLiquidLegionsSketchParams {
 // Sketch parameters for a Honest Majority Shuffle Based Secret Sharing
 // protocol.
 message ShareShuffleSketchParams {
-  reserved 1;
-
   // Length of each register in bytes.
   //
   // The product of `maximum_frequency` and the `nonce_hashes` count from the
   // `MeasurementSpec` should be no more than 2 ^ (`bytes_per_register` * 8).
-  int32 bytes_per_register = 2;
+  int32 bytes_per_register = 1;
 
   // The modulus used in the protocol. It is required to be greater than
   // (1 + `maximum_frequency`).
-  int32 ring_modulus = 3;
+  int32 ring_modulus = 2;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -77,6 +77,10 @@ message FulfillRequisitionRequest {
       // Requisition.DuchyEntry.HonestMajorityShareShuffle.
       EncryptedMessage secret_seed = 1;
 
+      // The number of registers in the sketch. The expansion of random seed is
+      // based on this value.
+      int64 register_count = 3;
+
       // Resource name of the `Certificate` belonging to the parent
       // `DataProvider` used to verify the secret_seed signature.
       string data_provider_certificate = 2 [

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -77,13 +77,17 @@ message FulfillRequisitionRequest {
       // Requisition.DuchyEntry.HonestMajorityShareShuffle.
       EncryptedMessage secret_seed = 1;
 
-      // The number of registers in the sketch. The expansion of random seed is
-      // based on this value.
-      int64 register_count = 3;
+      // The number of registers in the sketch.
+      //
+      // It is calculated by the DataProvider and is determined by the sampling
+      // interval and the size of the population being measured. It is expected
+      // that all DataProviders will yield the same value for a specific
+      // Computation.
+      int64 register_count = 2;
 
       // Resource name of the `Certificate` belonging to the parent
       // `DataProvider` used to verify the secret_seed signature.
-      string data_provider_certificate = 2 [
+      string data_provider_certificate = 3 [
         (google.api.resource_reference).type = "halo.wfanet.org/Certificate",
         (google.api.field_behavior) = REQUIRED
       ];


### PR DESCRIPTION
`register_count` is calculated by EDPs during sketch generation(All EDP should get the same value based on ProtocolConfig and vid model). So it is not included in ProtocolConfig but provided by RequisitionFulfillmentRequest.