### PR TITLE
Add `capabilities` field to `DataProvider` resource type.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -71,4 +71,15 @@ message DataProvider {
   // Interval for when data is guaranteed to be available for a `Requisition`.
   // If this field is specified, both `start_time` and `end_time` must be set.
   google.type.Interval data_availability_interval = 7;
+
+  // Capabilities of a `DataProvider`.
+  message Capabilities {
+    // Whether the Honest Majority Share Shuffle (HMSS) protocol is supported.
+    bool honest_majority_share_shuffle_supported = 1;
+  }
+  // Capabilities of this `DataProvider`.
+  //
+  // This indicates to the CMMS what the `DataProvider` is capable of at
+  // `Measurement` creation time.
+  Capabilities capabilities = 8;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_providers_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_providers_service.proto
@@ -47,6 +47,10 @@ service DataProviders {
     };
     option (google.api.method_signature) = "name,data_availability_interval";
   }
+
+  // Replaces the `capabilities` field in a `DataProvider` resource.
+  rpc ReplaceDataProviderCapabilities(ReplaceDataProviderCapabilitiesRequest)
+      returns (DataProvider) {}
 }
 
 // Request message for the `ReplaceDataProviderRequiredDuchies` method.
@@ -82,4 +86,16 @@ message ReplaceDataAvailabilityIntervalRequest {
   // New value for `data_availability_interval`.
   google.type.Interval data_availability_interval = 2
       [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for `ReplaceDataProviderCapabilities` method.
+message ReplaceDataProviderCapabilitiesRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // New value for `capabilities`.
+  DataProvider.Capabilities capabilities = 2;
 }


### PR DESCRIPTION
This includes a corresponding `ReplaceDataProviderCapabilities` method in the `DataProviders` service.

This is equivalent to #199, which was closed unintentionally.