### PR TITLE
Add MPC methodologies to Reach and Frequency result.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -190,11 +190,10 @@ proto_library(
 )
 
 proto_library(
-    name = "mpc_protocol_proto",
-    srcs = ["mpc_protocol.proto"],
+    name = "multi_party_computation_proto",
+    srcs = ["multi_party_computation.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
-        ":protocol_config_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
     ],
 )
@@ -216,7 +215,7 @@ proto_library(
     deps = [
         ":crypto_proto",
         ":direct_computation_proto",
-        ":mpc_protocol_proto",
+        ":multi_party_computation_proto",
         ":protocol_config_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -190,6 +190,16 @@ proto_library(
 )
 
 proto_library(
+    name = "mpc_protocol_proto",
+    srcs = ["mpc_protocol.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":protocol_config_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+    ],
+)
+
+proto_library(
     name = "protocol_config_proto",
     srcs = ["protocol_config.proto"],
     strip_import_prefix = IMPORT_PREFIX,
@@ -206,6 +216,7 @@ proto_library(
     deps = [
         ":crypto_proto",
         ":direct_computation_proto",
+        ":mpc_protocol_proto",
         ":protocol_config_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -22,7 +22,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/direct_computation.proto";
-import "wfa/measurement/api/v2alpha/mpc_protocol.proto";
+import "wfa/measurement/api/v2alpha/multi_party_computation.proto";
 import "wfa/measurement/api/v2alpha/protocol_config.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -168,14 +168,8 @@ message Measurement {
         // Liquid Legions count distinct methodology.
         LiquidLegionsCountDistinct liquid_legions_count_distinct = 5;
 
-        // Liquid Legions V2 methodology.
-        LiquidLegionsV2Methodology liquid_legions_v2 = 6;
-
-        // Reach Only Liquid Legions V2 methodology.
-        ReachOnlyLiquidLegionsV2Methodology reach_only_liquid_legions_v2 = 7;
-
         // Honest Majority Share Shuffle methodology.
-        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 8;
+        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 6;
       }
     }
     // The reach result.
@@ -211,11 +205,8 @@ message Measurement {
         // Liquid Legions distribution methodology.
         LiquidLegionsDistribution liquid_legions_distribution = 5;
 
-        // Liquid Legions V2 methodology.
-        LiquidLegionsV2Methodology liquid_legions_v2 = 6;
-
         // Honest Majority Share Shuffle methodology.
-        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 7;
+        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 6;
       }
     }
     // The frequency result.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -22,6 +22,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/direct_computation.proto";
+import "wfa/measurement/api/v2alpha/mpc_protocol.proto";
 import "wfa/measurement/api/v2alpha/protocol_config.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -171,13 +172,13 @@ message Measurement {
         LiquidLegionsCountDistinct liquid_legions_count_distinct = 5;
 
         // Liquid Legions V2 methodology.
-        LiquidLegionsV2 liquid_legions_v2 = 6;
+        LiquidLegionsV2Methodology liquid_legions_v2 = 6;
 
         // Reach Only Liquid Legions V2 methodology.
-        ReachOnlyLiquidLegionsV2 reach_only_liquid_legions_v2 = 7;
+        ReachOnlyLiquidLegionsV2Methodology reach_only_liquid_legions_v2 = 7;
 
         // Honest Majority Share Shuffle methodology.
-        HonestMajorityShareShuffle honest_majority_share_shuffle = 8;
+        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 8;
       }
     }
     // The reach result.
@@ -217,10 +218,10 @@ message Measurement {
         LiquidLegionsDistribution liquid_legions_distribution = 5;
 
         // Liquid Legions V2 methodology.
-        LiquidLegionsV2 liquid_legions_v2 = 6;
+        LiquidLegionsV2Methodology liquid_legions_v2 = 6;
 
         // Honest Majority Share Shuffle methodology.
-        HonestMajorityShareShuffle honest_majority_share_shuffle = 7;
+        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 7;
       }
     }
     // The frequency result.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -168,8 +168,14 @@ message Measurement {
         // Liquid Legions count distinct methodology.
         LiquidLegionsCountDistinct liquid_legions_count_distinct = 5;
 
+        // Liquid Legions V2 methodology.
+        LiquidLegionsV2Methodology liquid_legions_v2 = 6;
+
+        // Reach Only Liquid Legions V2 methodology.
+        ReachOnlyLiquidLegionsV2Methodology reach_only_liquid_legions_v2 = 7;
+
         // Honest Majority Share Shuffle methodology.
-        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 6;
+        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 8;
       }
     }
     // The reach result.
@@ -205,8 +211,11 @@ message Measurement {
         // Liquid Legions distribution methodology.
         LiquidLegionsDistribution liquid_legions_distribution = 5;
 
+        // Liquid Legions V2 methodology.
+        LiquidLegionsV2Methodology liquid_legions_v2 = 6;
+
         // Honest Majority Share Shuffle methodology.
-        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 6;
+        HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 7;
       }
     }
     // The frequency result.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -154,11 +154,8 @@ message Measurement {
       // incorporate the new API changes. --)
       ProtocolConfig.NoiseMechanism noise_mechanism = 2;
 
-      // The computation methodology done by data provider.
+      // The computation methodology.
       //
-      // Currently, only direct measurement and measurement via honest majority
-      // share shuffle protocol would populate it. During the transition of
-      // adopting this field, this field may not be specified.
       // (-- TODO(@riemanli): set required for new fulfillment once EDPs
       // incorporate the new API changes. --)
       oneof methodology {
@@ -200,11 +197,8 @@ message Measurement {
       // incorporate the new API changes. --)
       ProtocolConfig.NoiseMechanism noise_mechanism = 2;
 
-      // The computation methodology done by data provider.
+      // The computation methodology.
       //
-      // Currently, only direct measurement and measurement via honest majority
-      // share shuffle protocol would populate it. During the transition of
-      // adopting this field, this field may not be specified.
       // (-- TODO(@riemanli): set required for new fulfillment once EDPs
       // incorporate the new API changes. --)
       oneof methodology {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -155,8 +155,9 @@ message Measurement {
 
       // The computation methodology done by data provider.
       //
-      // Currently, only direct measurement would populate it. During the
-      // transition of adopting this field, this field may not be specified.
+      // Currently, only direct measurement and measurement via honest majority
+      // share shuffle protocol would populate it. During the transition of
+      // adopting this field, this field may not be specified.
       // (-- TODO(@riemanli): set required for new fulfillment once EDPs
       // incorporate the new API changes. --)
       oneof methodology {
@@ -168,6 +169,15 @@ message Measurement {
 
         // Liquid Legions count distinct methodology.
         LiquidLegionsCountDistinct liquid_legions_count_distinct = 5;
+
+        // Liquid Legions V2 methodology.
+        LiquidLegionsV2 liquid_legions_v2 = 6;
+
+        // Reach Only Liquid Legions V2 methodology.
+        ReachOnlyLiquidLegionsV2 reach_only_liquid_legions_v2 = 7;
+
+        // Honest Majority Share Shuffle methodology.
+        HonestMajorityShareShuffle honest_majority_share_shuffle = 8;
       }
     }
     // The reach result.
@@ -191,8 +201,9 @@ message Measurement {
 
       // The computation methodology done by data provider.
       //
-      // Currently, only direct measurement would populate it. During the
-      // transition of adopting this field, this field may not be specified.
+      // Currently, only direct measurement and measurement via honest majority
+      // share shuffle protocol would populate it. During the transition of
+      // adopting this field, this field may not be specified.
       // (-- TODO(@riemanli): set required for new fulfillment once EDPs
       // incorporate the new API changes. --)
       oneof methodology {
@@ -204,6 +215,12 @@ message Measurement {
 
         // Liquid Legions distribution methodology.
         LiquidLegionsDistribution liquid_legions_distribution = 5;
+
+        // Liquid Legions V2 methodology.
+        LiquidLegionsV2 liquid_legions_v2 = 6;
+
+        // Honest Majority Share Shuffle methodology.
+        HonestMajorityShareShuffle honest_majority_share_shuffle = 7;
       }
     }
     // The frequency result.

--- a/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
@@ -1,0 +1,64 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.api.v2alpha;
+
+import "google/api/field_behavior.proto";
+
+option java_package = "org.wfanet.measurement.api.v2alpha";
+option java_multiple_files = true;
+option java_outer_classname = "MpcProtocolProto";
+
+// Parameters for a Liquid Legions sketch.
+message LiquidLegionsSketchParams {
+  // The decay rate of the Liquid Legions sketch. Required.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. Required.
+  int64 max_size = 2;
+
+  // The size of the distribution of the sampling indicator value, i.e.
+  // fingerprint size. Required.
+  int64 sampling_indicator_size = 3;
+}
+
+// Parameters for a Reach-Only Liquid Legions sketch.
+message ReachOnlyLiquidLegionsSketchParams {
+  // The decay rate of the Liquid Legions sketch. REQUIRED.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. REQUIRED.
+  int64 max_size = 2;
+}
+
+message LiquidLegionsV2 {
+  // Parameters for sketch. REQUIRED.
+  LiquidLegionsSketchParams sketch_params = 1;
+
+  // The maximum frequency to reveal in the histogram.
+  int32 maximum_frequency = 4;
+}
+
+// Configuration for the Reach-Only Liquid Legions v2 protocol.
+message ReachOnlyLiquidLegionsV2 {
+  // Parameters for sketch. REQUIRED.
+  ReachOnlyLiquidLegionsSketchParams sketch_params = 1;
+}
+
+message HonestMajorityShareShuffle {
+  // The size of the sampled frequency vector. REQUIRED.
+  int64 frequency_vector_size = 1 [(google.api.field_behavior) = REQUIRED];
+}

--- a/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
@@ -17,34 +17,13 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
+import "wfa/measurement/api/v2alpha/protocol_config.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MpcProtocolProto";
 
-// Parameters for a Liquid Legions sketch.
-message LiquidLegionsSketchParams {
-  // The decay rate of the Liquid Legions sketch. Required.
-  double decay_rate = 1;
-
-  // The maximum size of the Liquid Legions sketch. Required.
-  int64 max_size = 2;
-
-  // The size of the distribution of the sampling indicator value, i.e.
-  // fingerprint size. Required.
-  int64 sampling_indicator_size = 3;
-}
-
-// Parameters for a Reach-Only Liquid Legions sketch.
-message ReachOnlyLiquidLegionsSketchParams {
-  // The decay rate of the Liquid Legions sketch. REQUIRED.
-  double decay_rate = 1;
-
-  // The maximum size of the Liquid Legions sketch. REQUIRED.
-  int64 max_size = 2;
-}
-
-message LiquidLegionsV2 {
+message LiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
   LiquidLegionsSketchParams sketch_params = 1;
 
@@ -53,12 +32,12 @@ message LiquidLegionsV2 {
 }
 
 // Configuration for the Reach-Only Liquid Legions v2 protocol.
-message ReachOnlyLiquidLegionsV2 {
+message ReachOnlyLiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
   ReachOnlyLiquidLegionsSketchParams sketch_params = 1;
 }
 
-message HonestMajorityShareShuffle {
+message HonestMajorityShareShuffleMethodology {
   // The size of the sampled frequency vector. REQUIRED.
   int64 frequency_vector_size = 1 [(google.api.field_behavior) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
@@ -23,19 +23,21 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MpcProtocolProto";
 
+// Configuration for the Liquid Legions v2 methodology.
 message LiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
   LiquidLegionsSketchParams sketch_params = 1
       [(google.api.field_behavior) = REQUIRED];
 }
 
-// Configuration for the Reach-Only Liquid Legions v2 protocol.
+// Configuration for the Reach-Only Liquid Legions v2 methodology.
 message ReachOnlyLiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
   ReachOnlyLiquidLegionsSketchParams sketch_params = 1
       [(google.api.field_behavior) = REQUIRED];
 }
 
+// Configuration for the Honest Majority Share Shuffle methodology.
 message HonestMajorityShareShuffleMethodology {
   // The size of the sampled frequency vector. REQUIRED.
   int64 frequency_vector_size = 1 [(google.api.field_behavior) = REQUIRED];

--- a/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
@@ -26,9 +26,6 @@ option java_outer_classname = "MpcProtocolProto";
 message LiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
   LiquidLegionsSketchParams sketch_params = 1;
-
-  // The maximum frequency to reveal in the histogram.
-  int32 maximum_frequency = 4;
 }
 
 // Configuration for the Reach-Only Liquid Legions v2 protocol.

--- a/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/mpc_protocol.proto
@@ -25,13 +25,15 @@ option java_outer_classname = "MpcProtocolProto";
 
 message LiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
-  LiquidLegionsSketchParams sketch_params = 1;
+  LiquidLegionsSketchParams sketch_params = 1
+      [(google.api.field_behavior) = REQUIRED];
 }
 
 // Configuration for the Reach-Only Liquid Legions v2 protocol.
 message ReachOnlyLiquidLegionsV2Methodology {
   // Parameters for sketch. REQUIRED.
-  ReachOnlyLiquidLegionsSketchParams sketch_params = 1;
+  ReachOnlyLiquidLegionsSketchParams sketch_params = 1
+      [(google.api.field_behavior) = REQUIRED];
 }
 
 message HonestMajorityShareShuffleMethodology {

--- a/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
@@ -22,6 +22,12 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MultiPartyComputationProto";
 
+// Configuration for the Liquid Legions v2 methodology.
+message LiquidLegionsV2Methodology {}
+
+// Configuration for the Reach-Only Liquid Legions v2 methodology.
+message ReachOnlyLiquidLegionsV2Methodology {}
+
 // Configuration for the Honest Majority Share Shuffle methodology.
 message HonestMajorityShareShuffleMethodology {
   // The size of the sampled frequency vector. REQUIRED.

--- a/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
@@ -17,25 +17,10 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
-import "wfa/measurement/api/v2alpha/protocol_config.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
-option java_outer_classname = "MpcProtocolProto";
-
-// Configuration for the Liquid Legions v2 methodology.
-message LiquidLegionsV2Methodology {
-  // Parameters for sketch. REQUIRED.
-  LiquidLegionsSketchParams sketch_params = 1
-      [(google.api.field_behavior) = REQUIRED];
-}
-
-// Configuration for the Reach-Only Liquid Legions v2 methodology.
-message ReachOnlyLiquidLegionsV2Methodology {
-  // Parameters for sketch. REQUIRED.
-  ReachOnlyLiquidLegionsSketchParams sketch_params = 1
-      [(google.api.field_behavior) = REQUIRED];
-}
+option java_outer_classname = "MultiPartyComputationProto";
 
 // Configuration for the Honest Majority Share Shuffle methodology.
 message HonestMajorityShareShuffleMethodology {


### PR DESCRIPTION
In HMSS protocol, the frequency vector size is not known until EDPs finish requisition fulfillment. EDPs will forward this information to the duchies. The aggregator also needs to include the frequency vector size in the result and send it to the measurement consumer so that it can compute HMSS variances.

This PR updates the Result message to include the MPC methodologies, which contain information needed by the measurement consumer to compute the metrics.