### PR TITLE
feat!: Add WITHDRAWN state to Requisition

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -184,6 +184,8 @@ message Requisition {
     //
     // `measurement` will be in the `FAILED` state.
     REFUSED = 3;
+    // The `Requisition` has been withdrawn. Terminal state.
+    WITHDRAWN = 4;
   }
   // The state of this `Requisition`.
   State state = 10 [(google.api.field_behavior) = OUTPUT_ONLY];


### PR DESCRIPTION
This change should generally be safe for DataProvider integrators:

- The common ListRequisitions request includes a filter for `Requisition.State.UNFULFILLED`
- Barring the above, any code that deals with protobuf enums is expected to gracefully handle unrecognized values.
  - For example, Java generated code includes an `UNRECOGNIZED` value for every protobuf enum.