### PR TITLE
Add dataProvider and update_time to Requisition

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -66,6 +66,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -263,5 +263,5 @@ message Requisition {
 
   // When the 'Requisition' was last updated.
   google.protobuf.Timestamp update_time = 17
-  [(google.api.field_behavior) = OUTPUT_ONLY];
+      [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -19,6 +19,7 @@ package wfa.measurement.api.v2alpha;
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/measurement.proto";
 import "wfa/measurement/api/v2alpha/protocol_config.proto";
@@ -259,4 +260,15 @@ message Requisition {
   // Denormalized `state` field from `measurement`.
   Measurement.State measurement_state = 13
       [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Resource name of `DataProvider` that this `Requisition` is associated with.
+  string dataProvider = 16 [
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // When the 'Requisition' was last updated.
+  google.protobuf.Timestamp update_time = 17
+  [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -261,13 +261,6 @@ message Requisition {
   Measurement.State measurement_state = 13
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Resource name of `DataProvider` that this `Requisition` is associated with.
-  string dataProvider = 16 [
-    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.field_behavior) = IMMUTABLE
-  ];
-
   // When the 'Requisition' was last updated.
   google.protobuf.Timestamp update_time = 17
   [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -262,6 +262,6 @@ message Requisition {
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // When the 'Requisition' was last updated.
-  google.protobuf.Timestamp update_time = 17
+  google.protobuf.Timestamp update_time = 16
       [(google.api.field_behavior) = OUTPUT_ONLY];
 }


### PR DESCRIPTION
These are needed for measurement prober metric (LastTerminalRequisitionTime) publication

LastTerminalRequisitionTime, will have an attribute “data provider” whose value is the name. The actual value of the metric will come from the update time of the requisition that is associated with the particular EDP for the most recently issued Measurement.