### PR TITLE
feat: Allow some methods to be proxied by grpc-gateway

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -592,6 +592,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":event_group_metadata_descriptor_proto",
+        "@com_google_googleapis//google/api:annotations_proto",
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/account.proto
@@ -22,6 +22,7 @@ import "google/api/resource.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "AccountProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // An API user account resource.
 message Account {

--- a/src/main/proto/wfa/measurement/api/v2alpha/accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/accounts_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/account.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "AccountsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `Account` resources.
 service Accounts {

--- a/src/main/proto/wfa/measurement/api/v2alpha/api_key.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/api_key.proto
@@ -22,6 +22,7 @@ import "google/api/resource.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ApiKeyProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing a revocable authentication key for an API resource.
 message ApiKey {

--- a/src/main/proto/wfa/measurement/api/v2alpha/api_keys_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/api_keys_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/api_key.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ApiKeysServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ApiKeys` resources.
 service ApiKeys {

--- a/src/main/proto/wfa/measurement/api/v2alpha/certificate.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/certificate.proto
@@ -22,6 +22,7 @@ import "google/api/resource.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "CertificateProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing an X.509 certificate.
 message Certificate {

--- a/src/main/proto/wfa/measurement/api/v2alpha/certificates_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/certificates_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/certificate.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "CertificatesServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `Certificate` resources.
 service Certificates {

--- a/src/main/proto/wfa/measurement/api/v2alpha/crypto.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/crypto.proto
@@ -22,6 +22,7 @@ import "google/protobuf/any.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "CryptoProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A public key in the ElGamal crypto system.
 message ElGamalPublicKey {

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/crypto.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DataProviderProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A provider of event (e.g. impression) data. For example, a publisher or panel
 // provider.

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_providers_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_providers_service.proto
@@ -26,11 +26,15 @@ import "wfa/measurement/api/v2alpha/data_provider.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DataProvidersServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `DataProvider` resources.
 service DataProviders {
   // Returns the `DataProvider` with the specified resource key.
   rpc GetDataProvider(GetDataProviderRequest) returns (DataProvider) {
+    option (google.api.http) = {
+      get: "/v2alpha/{name=dataProviders/*}"
+    };
     option (google.api.method_signature) = "name";
   }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/date_interval.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/date_interval.proto
@@ -21,6 +21,7 @@ import "google/type/date.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DateIntervalProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A date interval. This is intended for mirroring the existing
 // `google.type.Interval` proto message, replacing google.protobuf.Timestamp

--- a/src/main/proto/wfa/measurement/api/v2alpha/differential_privacy.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/differential_privacy.proto
@@ -19,6 +19,7 @@ package wfa.measurement.api.v2alpha;
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DifferentialPrivacyProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Parameters for differential privacy (DP).
 //

--- a/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/direct_computation.proto
@@ -21,6 +21,7 @@ import "google/api/field_behavior.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DirectComputationProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Information about the custom direct methodology.
 message CustomDirectMethodology {

--- a/src/main/proto/wfa/measurement/api/v2alpha/duchy.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/duchy.proto
@@ -22,6 +22,7 @@ import "google/api/resource.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "DuchyProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource message representing a Duchy.
 message Duchy {

--- a/src/main/proto/wfa/measurement/api/v2alpha/encrypted_sketch.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/encrypted_sketch.proto
@@ -19,6 +19,7 @@ package wfa.measurement.api.v2alpha;
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EncryptedSketchProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Encrypted generalized enriched cardinality sketch.
 //

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
@@ -26,6 +26,7 @@ import "google/protobuf/descriptor.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EventAnnotationsProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Descriptor for a field inside of an event template message.
 message EventFieldDescriptor {

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/crypto.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EventGroupProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A grouping of events defined by a `DataProvider`. For example, a single
 // campaign or creative defined in a publisher's ad system.

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptor.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptor.proto
@@ -22,6 +22,7 @@ import "google/protobuf/descriptor.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EventGroupMetadataDescriptorProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // The metadata message descriptor of an `EventGroup.Metadata`. This metadata is
 // used to describe the contents of an `EventGroup` without needing a direct

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptors_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptors_service.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
@@ -24,6 +25,7 @@ import "wfa/measurement/api/v2alpha/event_group_metadata_descriptor.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EventGroupMetadataDescriptorsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `EventGroupMetadataDescriptor` resources.
 service EventGroupMetadataDescriptors {
@@ -31,6 +33,9 @@ service EventGroupMetadataDescriptors {
   // name.
   rpc GetEventGroupMetadataDescriptor(GetEventGroupMetadataDescriptorRequest)
       returns (EventGroupMetadataDescriptor) {
+    option (google.api.http) = {
+      get: "/v2alpha/{name=dataProviders/*/eventGroupMetadataDescriptors/*}"
+    };
     option (google.api.method_signature) = "name";
   }
 
@@ -59,7 +64,11 @@ service EventGroupMetadataDescriptors {
   // if any of the specified `EventGroupMetadataDescriptor`s does not exist.
   rpc BatchGetEventGroupMetadataDescriptors(
       BatchGetEventGroupMetadataDescriptorsRequest)
-      returns (BatchGetEventGroupMetadataDescriptorsResponse) {}
+      returns (BatchGetEventGroupMetadataDescriptorsResponse) {
+    option (google.api.http) = {
+      get: "/v2alpha/{parent=dataProviders/*}/eventGroupMetadataDescriptors:batchGet"
+    };
+  }
 
   // Lists `EventGroupMetadataDescriptor`s. Results in a `PERMISSION_DENIED`
   // error if attempting to list `EventGroupMetadataDescriptor`s that the

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/event_group.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EventGroupsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `EventGroup` resources.
 service EventGroups {

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_template.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_template.proto
@@ -21,6 +21,7 @@ import "google/api/field_behavior.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "EventTemplateProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Template for an event message.
 message EventTemplate {

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange.proto
@@ -23,6 +23,7 @@ import "google/type/date.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource that represents an instance of a `RecurringExchange` for a single
 // date.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -24,6 +24,7 @@ import "google/type/date.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeStepProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // API resource representing an ExchangeWorkflow.Step for a particular Exchange.
 message ExchangeStep {

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
@@ -23,6 +23,7 @@ import "google/protobuf/timestamp.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeStepAttemptProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // An attempt (successful or not) of an ExchangeStep.
 message ExchangeStepAttempt {

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempts_service.proto
@@ -23,6 +23,7 @@ import "wfa/measurement/api/v2alpha/exchange_step_attempt.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeStepAttemptsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ExchangeStepAttempt` resources.
 //

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_steps_service.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/exchange_step.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeStepsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ExchangeStep` resources.
 service ExchangeSteps {

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
@@ -23,6 +23,7 @@ import "google/type/date.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangeWorkflowProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // The representation for the Panel Matching Workflow. These are unique per
 // recurring exchange as they contain the identities of each party.

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchanges_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchanges_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/exchange.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ExchangesServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `Exchange` resources.
 service Exchanges {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -29,6 +29,7 @@ import "wfa/measurement/api/v2alpha/protocol_config.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MeasurementProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A measurement from a set of `DataProvider`s requested by a
 // `MeasurementConsumer`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
@@ -23,6 +23,7 @@ import "wfa/measurement/api/v2alpha/crypto.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MeasurementConsumerProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A consumer of `Measurement` results. For example, an advertiser or ad agency.
 message MeasurementConsumer {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumers_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumers_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/measurement_consumer.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MeasurementConsumersServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `MeasurementConsumer` resources.
 service MeasurementConsumers {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_spec.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/differential_privacy.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MeasurementSpecProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Specification for a `Measurement`. Immutable.
 message MeasurementSpec {

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/measurement.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MeasurementsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `Measurement` resources.
 service Measurements {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_line.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_line.proto
@@ -23,6 +23,7 @@ import "google/protobuf/timestamp.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelLineProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing a series of models within a model suite.
 message ModelLine {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_lines_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_lines_service.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/model_line.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelLinesServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelLine` resources.
 service ModelLines {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_outage.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_outage.proto
@@ -24,6 +24,7 @@ import "google/type/interval.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelOutageProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing an outage of a model line.
 message ModelOutage {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_outages_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_outages_service.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/model_outage.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelOutagesServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelOutage` resources.
 service ModelOutages {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_provider.proto
@@ -21,6 +21,7 @@ import "google/api/resource.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelProviderProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // The party that builds VID Models.
 message ModelProvider {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_providers_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_providers_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/model_provider.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelProvidersServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelProvider` resources.
 service ModelProviders {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_release.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_release.proto
@@ -23,6 +23,7 @@ import "google/protobuf/timestamp.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelReleaseProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing a release of a model.
 message ModelRelease {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_releases_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_releases_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/model_release.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelReleasesServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelRelease` resources.
 service ModelReleases {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_rollout.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_rollout.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/date_interval.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelRolloutProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing the rollout of a `ModelLine`.
 message ModelRollout {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_rollouts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_rollouts_service.proto
@@ -27,6 +27,7 @@ import "wfa/measurement/api/v2alpha/model_rollout.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelRolloutsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelRollout` resources.
 service ModelRollouts {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
@@ -23,6 +23,7 @@ import "google/protobuf/timestamp.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelShardProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Resource representing a shard of a model for a `DataProvider`.
 message ModelShard {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_shards_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_shards_service.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/model_shard.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelShardsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelShard` resources.
 service ModelShards {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_suite.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_suite.proto
@@ -23,6 +23,7 @@ import "google/protobuf/timestamp.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelSuiteProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A suite of model lines provided by a `ModelProvider`.
 message ModelSuite {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_suites_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_suites_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/model_suite.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ModelSuitesServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `ModelSuite` resources.
 service ModelSuites {

--- a/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
@@ -21,6 +21,7 @@ import "google/api/field_behavior.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "MultiPartyComputationProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Configuration for the Liquid Legions v2 methodology.
 message LiquidLegionsV2Methodology {}

--- a/src/main/proto/wfa/measurement/api/v2alpha/population.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/population.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/event_template.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "PopulationProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A population provided by a `DataProvider`.
 message Population {

--- a/src/main/proto/wfa/measurement/api/v2alpha/population_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/population_spec.proto
@@ -23,6 +23,7 @@ import "wfa/measurement/api/v2alpha/event_template.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "PopulationSpecProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Specification for a `Population`. Immutable.
 message PopulationSpec {

--- a/src/main/proto/wfa/measurement/api/v2alpha/populations_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/populations_service.proto
@@ -24,6 +24,7 @@ import "wfa/measurement/api/v2alpha/population.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "PopulationsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `Population` resources.
 service Populations {

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -22,6 +22,7 @@ import "wfa/measurement/api/v2alpha/differential_privacy.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ProtocolConfigProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Configuration for computation protocols.
 //

--- a/src/main/proto/wfa/measurement/api/v2alpha/public_key.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/public_key.proto
@@ -23,6 +23,7 @@ import "wfa/measurement/api/v2alpha/crypto.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "PublicKeyProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Singleton resource representing an encryption public key.
 message PublicKey {

--- a/src/main/proto/wfa/measurement/api/v2alpha/public_keys_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/public_keys_service.proto
@@ -23,6 +23,7 @@ import "wfa/measurement/api/v2alpha/public_key.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "PublicKeysServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `PublicKey` resources.
 service PublicKeys {

--- a/src/main/proto/wfa/measurement/api/v2alpha/random_seed.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/random_seed.proto
@@ -19,6 +19,7 @@ package wfa.measurement.api.v2alpha;
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RandomSeedProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A random seed that can be expanded into a deterministic blob using a
 // specific PRNG function.

--- a/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
@@ -24,6 +24,7 @@ import "google/type/date.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RecurringExchangeProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A Panel Matching exchange that happens between a DataProvider and a
 // ModelProvider on some schedule. This is instantiated once per date in the

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -27,6 +27,7 @@ import "wfa/measurement/api/v2alpha/protocol_config.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // A requisition for data across `EventGroup`s from a single `DataProvider`.
 // Output-only.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -25,6 +25,7 @@ import "wfa/measurement/api/v2alpha/requisition.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionFulfillmentServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Duchy service for fulfilling `Requisition`s.
 service RequisitionFulfillment {

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
@@ -24,6 +24,7 @@ import "google/type/interval.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionSpecProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Specification for a `Requisition` which can be cryptographically signed.
 // Immutable.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
@@ -26,6 +26,7 @@ import "wfa/measurement/api/v2alpha/requisition.proto";
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `Requisition` resources.
 service Requisitions {


### PR DESCRIPTION
These methods are proxied in the Reporting API server, and thus must be compatible with grpc-gateway.

* GetDataProvider
* GetEventGroupMetadataDescriptor
* BatchGetEventGroupMetadataDescriptors