### PR TITLE
fix: Address API linter warnings

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -25,18 +25,18 @@ on:
 jobs:
   lint:
     name: API lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up api-linter
       uses: world-federation-of-advertisers/actions/setup-api-linter@v2
       with:
-        version: 1.56.1
-        sha256: 4f7ca3e11d3c9a72b894a547e4e3a174fcd826885a875e484777f1eb23d885b4
+        version: 1.69.2
+        sha256: f2d1b0fb8df62676ebc49cc905c4e1ae4b82590bca156c612ac3456e1686b1cc
 
     - env:
         BAZEL: bazelisk

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -163,6 +163,7 @@ proto_library(
     srcs = ["event_group_metadata_descriptor.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_protobuf//:descriptor_proto",
     ],
@@ -272,6 +273,7 @@ proto_library(
     srcs = ["model_provider.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/account.proto
@@ -51,7 +51,7 @@ message Account {
   }
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Resource name of the `Account` that created this one.
   string creator = 2 [

--- a/src/main/proto/wfa/measurement/api/v2alpha/api_key.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/api_key.proto
@@ -34,7 +34,7 @@ message ApiKey {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Human-readable nickname for this `ApiKey`.
   string nickname = 2 [(google.api.field_behavior) = REQUIRED];

--- a/src/main/proto/wfa/measurement/api/v2alpha/certificate.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/certificate.proto
@@ -40,7 +40,7 @@ message Certificate {
   //
   // The resource ID alias "preferred" may be used in place of the `Certificate`
   // ID to refer to the *preferred* `Certificate`.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // X.509 certificate in DER format. Required. Immutable.
   bytes x509_der = 2 [

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -37,7 +37,7 @@ message DataProvider {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The X.509 certificate belonging to this `DataProvider` in DER format which
   // can be used to verify `public_key`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/duchy.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/duchy.proto
@@ -34,7 +34,7 @@ message Duchy {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The *preferred* X.509 certificate belonging to this `Duchy` in DER format.
   bytes preferred_certificate_der = 2 [(google.api.field_behavior) = REQUIRED];

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -45,7 +45,7 @@ message EventGroup {
   // Resource name.
   //
   // Canonical format: dataProviders/{data_provider}/eventGroups/{event_group}
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Resource name of the `MeasurementConsumer` associated with this
   // `EventGroup`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata.proto
@@ -23,18 +23,22 @@ option java_multiple_files = true;
 option java_outer_classname = "EventGroupMetadataProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
-// Metadata for EventGroups.
+// Common metadata structure for an [EventGroup][].
 message EventGroupMetadata {
-  // Metadata specific to ad impressions.
+  // Metadata for an [EventGroup][] containing ad impression events.
   message AdMetadata {
-    // Metadata that pertains to a campaign.
+    // Metadata for a brand advertising campaign.
     message CampaignMetadata {
       // The name of the brand for which the campaign is being run.
+      // (-- api-linter: core::0122::name-suffix=disabled
+      //     aip.dev/not-precedent: This is not a resource reference. --)
       string brand_name = 1 [(google.api.field_behavior) = REQUIRED];
       // The name of the campaign.
+      // (-- api-linter: core::0122::name-suffix=disabled
+      //     aip.dev/not-precedent: This is not a resource reference. --)
       string campaign_name = 2 [(google.api.field_behavior) = REQUIRED];
     }
-    // Metadata the pertains to a campaign that is entailed by the EventGroup.
+    // Metadata for a brand advertising campaign.
     CampaignMetadata campaign_metadata = 1
         [(google.api.field_behavior) = REQUIRED];
   }
@@ -43,6 +47,7 @@ message EventGroupMetadata {
   // entailed by an EventGroup.
   // Required.
   oneof selector {
+    // Metadata for an [EventGroup][] containing ad impression events.
     AdMetadata ad_metadata = 2;
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptor.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptor.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/descriptor.proto";
 
@@ -39,7 +40,7 @@ message EventGroupMetadataDescriptor {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // `FileDescriptorSet` including the `FileDescriptorProto` of the metadata
   // message and the transitive closure of its dependencies.

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptors_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata_descriptors_service.proto
@@ -110,6 +110,8 @@ message CreateEventGroupMetadataDescriptorRequest {
   //
   // If specified, the request will be idempotent. See
   // https://google.aip.dev/155.
+  // (-- api-linter: core::0155::request-id-format=disabled
+  //     aip.dev/not-precedent: This field predates the format requirement. --)
   string request_id = 3;
 }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -91,6 +91,8 @@ message CreateEventGroupRequest {
   //
   // If specified, the request will be idempotent. See
   // https://google.aip.dev/155.
+  // (-- api-linter: core::0155::request-id-format=disabled
+  //     aip.dev/not-precedent: This field predates the format requirement. --)
   string request_id = 3;
 }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange.proto
@@ -38,7 +38,7 @@ message Exchange {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Date of the Exchange. Must be a complete date (no field can be unset/zero).
   google.type.Date date = 2 [(google.api.field_behavior) = REQUIRED];

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step.proto
@@ -40,7 +40,7 @@ message ExchangeStep {
   reserved 3;
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Denormalized `date` from the parent `Exchange`.
   //

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_step_attempt.proto
@@ -37,7 +37,7 @@ message ExchangeStepAttempt {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // An ExchangeStep can have multiple ExchangeStepAttempts. When sorted by
   // `start_time`, these form a contiguous sequence of integers starting at 1.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -42,7 +42,7 @@ message Measurement {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Resource name of the `Certificate` belonging to the parent
   // `MeasurementConsumer`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement_consumer.proto
@@ -35,7 +35,7 @@ message MeasurementConsumer {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The X.509 certificate belonging to this `MeasurementConsumer` in DER format
   // which can be used to verify `public_key`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -88,6 +88,8 @@ message CreateMeasurementRequest {
   //
   // If specified, the request will be idempotent. See
   // https://google.aip.dev/155.
+  // (-- api-linter: core::0155::request-id-format=disabled
+  //     aip.dev/not-precedent: This field predates the format requirement. --)
   string request_id = 2;
 }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_line.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_line.proto
@@ -35,7 +35,7 @@ message ModelLine {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Human-readable display name for this 'ModelLine'.
   string display_name = 2;
@@ -86,6 +86,9 @@ message ModelLine {
   // `PROD` can have a holdback model line set. Any attempt of setting a
   // holdback model line to a 'ModelLine' that does not have type equals to
   // 'PROD' will result in an error.
+  // (-- api-linter: core::0121::no-mutable-cycles=disabled
+  //     aip.dev/not-precedent: This complexity is needed to support holdbacks.
+  //     --)
   string holdback_model_line = 7
       [(google.api.resource_reference).type = "halo.wfanet.org/ModelLine"];
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_outage.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_outage.proto
@@ -36,7 +36,7 @@ message ModelOutage {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // google.type.Interval in which the parent `ModelLine` cannot be used to
   // generate sketches. If a report spans across one or more `ModelOutage`s, the

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_provider.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -33,7 +34,7 @@ message ModelProvider {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Display name of the `ModelProvider`.
   string display_name = 2;

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_release.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_release.proto
@@ -35,7 +35,7 @@ message ModelRelease {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // When the 'ModelRelease' was created.
   google.protobuf.Timestamp create_time = 2

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_rollout.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_rollout.proto
@@ -18,8 +18,8 @@ package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
-import "google/type/date.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
 import "wfa/measurement/api/v2alpha/date_interval.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -39,7 +39,7 @@ message ModelRollout {
   reserved 2;
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Determine the type of rollout for this ModelRollout. Required.
   oneof rollout_deploy_period {

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
@@ -35,7 +35,7 @@ message ModelShard {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Resource name of the `ModelRelease` that this is a shard of.
   string model_release = 2 [

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_suite.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_suite.proto
@@ -35,7 +35,7 @@ message ModelSuite {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Human-readable nickname for this ModelSuite.
   string display_name = 2 [(google.api.field_behavior) = REQUIRED];

--- a/src/main/proto/wfa/measurement/api/v2alpha/population.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/population.proto
@@ -36,7 +36,7 @@ message Population {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The 'Population' description.
   string description = 2;

--- a/src/main/proto/wfa/measurement/api/v2alpha/public_key.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/public_key.proto
@@ -36,7 +36,7 @@ message PublicKey {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Serialized `EncryptionPublicKey` for the parent resource, which can be
   // verified using `certificate`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/recurring_exchange.proto
@@ -40,7 +40,7 @@ message RecurringExchange {
   };
 
   // Resource name.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The `ExchangeWorkflow` for this `RecurringExchange`.
   //

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -47,7 +47,7 @@ message Requisition {
   // Resource name.
   //
   // Canonical format: dataProviders/{data_provider}/requisitions/{requisition}
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Resource name of `Measurement` that this `Requisition` is associated with.
   string measurement = 2 [

--- a/tools/api-lint
+++ b/tools/api-lint
@@ -24,8 +24,12 @@ set -eu -o pipefail
 readonly BAZEL="${BAZEL:-bazel}"
 readonly PROTO_PATH='src/main/proto'
 
+get_proto_library_deps() {
+  "$BAZEL" query "${deps_query}"
+}
+
 get_descriptor_sets() {
-  "$BAZEL" cquery "kind('^proto_library rule', deps(${target}))" --output=files
+  "$BAZEL" cquery "${deps_query}" --output=files
 }
 
 get_proto_files() {
@@ -33,6 +37,10 @@ get_proto_files() {
     -path "$PROTO_PATH/${path}/*" \
     -name '*.proto' \
     -printf '%P\0'
+}
+
+build() {
+  get_proto_library_deps | xargs "$BAZEL" build
 }
 
 lint() {
@@ -51,10 +59,11 @@ lint() {
 main() {
   readonly path="$1"
   shift 1
-  
-  readonly target="//$PROTO_PATH/${path}/..."
-  "$BAZEL" build "${target}"
 
+  readonly target="//$PROTO_PATH/${path}/..."
+  readonly deps_query="kind('^proto_library rule', deps(${target}))"
+
+  build
   lint "$@"
 }
 


### PR DESCRIPTION
Some of these were introduced in #225.

This also updates api-linter to v1.69.2.