### PR TITLE
docs: Clarify documentation of data availability fields

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -87,7 +87,7 @@ message DataProvider {
   // `Measurement` creation time.
   Capabilities capabilities = 8;
 
-  // Per `ModelLine` data availabiity
+  // An entry in the [data_availability_intervals][] map.
   message DataAvailabilityMapEntry {
     // Resource name of a `ModelLine`
     string key = 1 [
@@ -95,14 +95,24 @@ message DataProvider {
       (google.api.field_behavior) = REQUIRED
     ];
 
-    // Interval for when data is guaranteed to be available for a `Requisition`
-    // fulfillment. If this field is specified, both `start_time` and `end_time`
-    // must be set.
+    // Interval for when data is guaranteed to be available for a
+    // [Requisition][] fulfillment for the [ModelLine][] indicated by [key][].
+    //
+    // A [DataProvider][] must only specify availability for intervals
+    // when they are guaranteed to have the data available to fulfill any
+    // [Requisition][] within that interval. See
+    // [RequisitionSpec.EventGroupEntry.Value.collection_interval][].
+    //
+    // If this field is specified, both `start_time` and `end_time` must be set.
     google.type.Interval value = 2 [(google.api.field_behavior) = REQUIRED];
   }
-  // `DataAvailability` for each `ModelLine` that the `DataProvider` supports.
+  // A map of [ModelLine][] resource name to data availability interval.
+  //
   // TODO(@kungfucraig): Make this REQUIRED once it has been adopted, and no
-  // earlier than the 0.7 release.
+  // earlier than the 0.7 release. Once this is required, it may be an error to
+  // create a [Measurement][] unless the interval specified by
+  // [RequisitionSpec][] does not fall into the availability interval for
+  // [MeasurementSpec.model_line][].
   repeated DataAvailabilityMapEntry data_availability_intervals = 9
       [(google.api.field_behavior) = UNORDERED_LIST];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -168,16 +168,16 @@ message EventGroup {
   // Event Group state.
   State state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Interval for when events for this `EventGroup` are available.
+  // Interval for which this [EventGroup][] has events.
   //
-  // For an Ad Campaign these are the start and end dates of the campaign.
+  // When this field is specified, [start_time][google.type.Interval.start_time]
+  // is required. If [end_time][google.type.Interval.end_time] is not specified,
+  // the interval is considered unbounded.
   //
-  // Events are available in the range specified here, but are only guaranteed
-  // to be available for reporting for a paticular `ModelLine` where this range
-  // intersects with the `data_availability_intervals` set forth on the
-  // `DataProvider` for the particular `ModelLine`
+  // If this [EventGroup][] represents an ad campaign, this is typically the
+  // start and end times of the campaign.
   //
   // TODO(@kungfucraig): Make this REQUIRED once it has been adopted. This will
-  // happen no sooner than the 0.6 relesae.
+  // happen no sooner than the 0.6 release.
   google.type.Interval data_availability_interval = 11;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -145,7 +145,10 @@ message Measurement {
   message Result {
     // A reach result.
     message Reach {
-      // Number of unique users exposed.
+      // Number of unique users (VIDs) for which there are impression events.
+      //
+      // This must be non-negative, meaning any negative value arising due to
+      // noise must be clamped to 0.
       int64 value = 1;
 
       // The mechanism used to generate noise during computation.
@@ -183,9 +186,13 @@ message Measurement {
     // A frequency result.
     message Frequency {
       // Map of frequency to reach ratio. For example, an entry
-      // {key: 4 value: 0.333} means that 33.3% of users were exposed exactly 4
-      // times, unless 4 is the largest key (maximum frequency) in which case it
-      // means that 33.3% of users were exposed at least 4 times.
+      // {key: 4 value: 0.333} means that 33.3% of users have exactly 4
+      // impression events, unless 4 is the largest key (maximum frequency) in
+      // which case it means that 33.3% of users have *at least* 4 impression
+      // events.
+      //
+      // Values must be non-negative, meaning any negative value arising due to
+      // noise must be clamped to 0.
       map<int64, double> relative_frequency_distribution = 1;
 
       // The mechanism used to generate noise during computation.
@@ -219,7 +226,10 @@ message Measurement {
 
     // An impression result.
     message Impression {
-      // Number of total impressions.
+      // Number of impression events.
+      //
+      // This must be non-negative, meaning any negative value arising due to
+      // noise must be clamped to 0.
       int64 value = 1;
 
       // The mechanism used to generate noise during computation.
@@ -245,6 +255,9 @@ message Measurement {
     // A watch duration result.
     message WatchDuration {
       // Total duration.
+      //
+      // This must be non-negative, meaning any negative value arising due to
+      // noise must be clamped to 0.
       google.protobuf.Duration value = 1;
 
       // The mechanism used to generate noise during computation.
@@ -270,6 +283,8 @@ message Measurement {
     // A population result.
     message Population {
       // The population value.
+      //
+      // This must be non-negative.
       int64 value = 1;
 
       // The computation methodology done by data provider. Required.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -238,14 +238,27 @@ message Requisition {
       // This implies that the `DataProvider` *should* be able to fulfill the
       // `Requisition`, but something went irrecoverably wrong. For example, the
       // `DataProvider` encountered corruption of the underlying data.
+      //
+      // This indicates a failure within the `DataProvider`'s fulfillment
+      // mechanism.
       UNFULFILLABLE = 4;
 
       // The `DataProvider` has declined to fulfill this `Requisition`
       // regardless of whether any of the other `Justification` conditions
       // apply.
+      //
+      // For example, a `DataProvider` policy that cannot be expressed within
+      // the API.
       DECLINED = 5;
     }
-    // Justification for refusing to fulfill this `Requisition`.
+    // Justification for refusing to fulfill this [Requisition][].
+    //
+    // Note that there is no [Justification][] for
+    // [collection_interval][RequisitionSpec.EventGroupEntry.Value.collection_interval]
+    // falling outside of [EventGroup.data_availability_interval][], as that is
+    // allowed behavior. See the documentation for
+    // [RequisitionSpec.EventGroupEntry.Value.collection_interval][] for more
+    // details.
     Justification justification = 1 [(google.api.field_behavior) = REQUIRED];
 
     // Human-readable string adding more context to the provided

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -29,7 +29,11 @@ option go_package = "github.com/world-federation-of-advertisers/cross-media-meas
 
 // Duchy service for fulfilling `Requisition`s.
 service RequisitionFulfillment {
-  // Fulfills a `Requisition`.
+  // Fulfills a [Requisition][] using a protocol other than
+  // [Direct][ProtocolConfig.Direct].
+  //
+  // See [Requisitions.FulfillDirectRequisition][] for fulfilling a
+  // [Requisition][] using the [Direct][ProtocolConfig.Direct] protocol.
   rpc FulfillRequisition(stream FulfillRequisitionRequest)
       returns (FulfillRequisitionResponse) {}
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
@@ -45,9 +45,17 @@ message RequisitionSpec {
 
     // Value of an `EventGroupEntry`.
     message Value {
-      // Time interval over which the event data should be collected.
+      // Time interval over which event data is collected for fulfillment.
       //
-      // Both `start_time` and `end_time` must be specified.
+      // Both [start_time][google.type.Interval.start_time] and
+      // [end_time][google.type.Interval.end_time] must be specified.
+      //
+      // Only events in the intersection of this, the
+      // [DataProvider.data_availability_intervals][] entry for
+      // [MeasurementSpec.model_line][], and the
+      // [EventGroup.data_availability_interval][] for the [EventGroup][]
+      // matching [key][] need be included. Outside of that intersection, the
+      // [EventGroup][] may be considered to have 0 events.
       google.type.Interval collection_interval = 1
           [(google.api.field_behavior) = REQUIRED];
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
@@ -36,16 +36,22 @@ service Requisitions {
     option (google.api.method_signature) = "parent";
   }
 
-  // Transitions a `Requisition` to the `REFUSED` state.
+  // Transitions a [Requisition][] to the [REFUSED][Requisition.State.REFUSED]
+  // state.
   //
-  // This is a terminal state for the `Requisition` and all computations that
-  // rely on the `Requisition` will fail. Consequently, this should only be used
-  // for permanent failures and not transient errors.
+  // This is a terminal state for the [Requisition][], resulting in the
+  // permanent failure of the parent [Measurement][]. Consequently, this should
+  // only be called for permanent failures and not transient errors.
   //
-  // This is a state transition method (see https://aip.dev/216).
+  // This is a [state transition method](https://aip.dev/216).
   rpc RefuseRequisition(RefuseRequisitionRequest) returns (Requisition);
 
-  // Fulfills a `Requisition` directly without calling a `Duchy`.
+  // Fulfills a [Requisition][] using the [Direct][ProtocolConfig.Direct]
+  // protocol.
+  //
+  // This may only be called if [Requisition.protocol_config][] indicates that
+  // the protocol may be used. See the [RequisitionFulfillment][] service to
+  // fulfill using a different protocol.
   rpc FulfillDirectRequisition(FulfillDirectRequisitionRequest)
       returns (FulfillDirectRequisitionResponse);
 }


### PR DESCRIPTION
This attempts to resolve the ambiguity of how Requisitions should be fulfilled when any part of the interval falls outside of the effective data availability interval of an EventGroup. Specifically, that Requisitions should be fulfilled as if there were 0 events outside of that interval (as opposed to being refused).