### PR TITLE
docs: Clarify which intervals EnumerateValidModelLines considers

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -105,14 +105,19 @@ message DataProvider {
     // [Requisition][] within that interval. See
     // [RequisitionSpec.EventGroupEntry.Value.collection_interval][].
     //
-    // If this field is specified, both `start_time` and `end_time` must be set.
+    // This interval must be fully contained by the active range of the
+    // corresponding [ModelLine][].
+    //
+    // If this field is specified, both
+    // [start_time][google.type.Interval.start_time] and
+    // [end_time][google.type.Interval.end_time] must be set.
     google.type.Interval value = 2 [(google.api.field_behavior) = REQUIRED];
   }
   // A map of [ModelLine][] resource name to data availability interval.
   //
   // TODO(@kungfucraig): Make this REQUIRED once it has been adopted, and no
   // earlier than the 0.7 release. Once this is required, it may be an error to
-  // create a [Measurement][] unless the interval specified by
+  // create a [Measurement][] if the interval specified by
   // [RequisitionSpec][] does not fall into the availability interval for
   // [MeasurementSpec.model_line][].
   repeated DataAvailabilityMapEntry data_availability_intervals = 9

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_lines_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_lines_service.proto
@@ -57,8 +57,10 @@ service ModelLines {
   rpc SetModelLineActiveEndTime(SetModelLineActiveEndTimeRequest)
       returns (ModelLine);
 
-  // Lists `ModelLine`s that are valid given an `Interval` representing the time
-  // range and a set of `DataProvider`s. Ordered by `type` from `PROD` to
+  // Enumerates the [ModelLine][]s which are available across all specified
+  // [DataProvider][]s for the specified time interval.
+  //
+  // Results are ordered by `type` from `PROD` to
   // `HOLDBACK` to `DEV`, `active_start_time` descending.
   rpc EnumerateValidModelLines(EnumerateValidModelLinesRequest)
       returns (EnumerateValidModelLinesResponse);
@@ -166,18 +168,13 @@ message EnumerateValidModelLinesRequest {
     (google.api.field_behavior) = REQUIRED
   ];
 
-  // If `active_end_time` is set, only `ModelLine`s with this interval fully
-  // contained between  `active_start_time`  and `active_end_time` are
-  // considered. If `active_end_time` is not set, then the `start_time` of this
-  // interval needs to be after `active_start_time` for the `ModelLine` to be
-  // considered.
+  // The time interval for which all [data_providers][] must have data available
+  // for [ModelLine][] to be included in the response.
   google.type.Interval time_interval = 2
       [(google.api.field_behavior) = REQUIRED];
 
-  // Each `data_availability_intervals` must have an entry for the `ModelLine`
-  // for the `ModelLine` to be considered, and the interval in each entry
-  // associated with the `ModelLine` must fully contain the `time_interval` for
-  // the `ModelLine` to be considered.
+  // The resource names of the [DataProvider][]s which must have data available
+  // for a [ModelLine][] to be included in the response.
   repeated string data_providers = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"


### PR DESCRIPTION
The primary use case of the method is for a MeasurementConsumer caller to determine which ModelLine to specify for a Measurement. For this purpose, only the DataProvider data availability for each ModelLine is relevant. The active range of the ModelLine is only transitively considered by the fact that DataProvider data availability is inherently constrained by the ModelLine active range.

Issue: world-federation-of-advertisers/cross-media-measurement#2998