### PR TITLE
feat: Add reversed direction data availability filters to ListEventGroups

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -216,6 +216,14 @@ message ListEventGroupsRequest {
     // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
     // must be on or before.
     google.protobuf.Timestamp data_availability_end_time_on_or_before = 4;
+    // Time which
+    // [EventGroup.data_availability_interval.start_time][google.type.Interval.start_time]
+    // must be on or before.
+    google.protobuf.Timestamp data_availability_start_time_on_or_before = 7;
+    // Time which
+    // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
+    // must be on or after.
+    google.protobuf.Timestamp data_availability_end_time_on_or_after = 8;
     // Query for text search on string fields in
     // [EventGroup.event_group_metadata][].
     string metadata_search_query = 5;


### PR DESCRIPTION
Issue: world-federation-of-advertisers/cross-media-measurement#3078