### PR TITLE
feat: Allow ModelLine.type to be mutated, deprecating the unused HOLDBACK type.

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/model_line.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_line.proto
@@ -61,35 +61,34 @@ message ModelLine {
     // The default value if 'Type' is omitted. Should not be used.
     TYPE_UNSPECIFIED = 0;
     // DEV `ModelLine`s are used to test new `ModelRelease`s. They are not
-    // available to `MeasurementConsumer`s when generating reports.
+    // available to all `MeasurementConsumer`s when generating reports.
     DEV = 1;
     // Default 'ModelLine' that must be used to generate reports for
     // `MeasurementConsumer`s.
     PROD = 2;
     // Used to generate reports in case of PROD 'ModelLine' outages. Holdback
     // 'ModelLine' should only includes stable and bug-free 'ModelRelease's.
-    HOLDBACK = 3;
+    HOLDBACK = 3 [deprecated = true];
   }
 
   // Type of this `ModelLine`.
   //
   // `DataProvider`s must label events using all available `ModelLine`s
   // independently of their type.
-  Type type = 6 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.field_behavior) = IMMUTABLE
-  ];
+  Type type = 6 [(google.api.field_behavior) = REQUIRED];
 
-  // The holdback 'ModelLine' that must be used to generate reports in case this
-  // `ModelLine` presents outages. Only 'ModelLine's having `type` equal to
-  // `PROD` can have a holdback model line set. Any attempt of setting a
-  // holdback model line to a 'ModelLine' that does not have type equals to
-  // 'PROD' will result in an error.
+  // The holdback [ModelLine][] that must be used to generate reports in case
+  // this [ModelLine][] presents outages. May only be set if [type][] is
+  // [ModelLine.Type.PROD][]. The [type][] of the referenced [ModelLine][] must
+  // be [ModelLine.Type.HOLDBACK][].
   // (-- api-linter: core::0121::no-mutable-cycles=disabled
-  //     aip.dev/not-precedent: This complexity is needed to support holdbacks.
+  //     aip.dev/not-precedent: This is not cyclical as it can only ever refer
+  //     to a different ModelLine.
   //     --)
-  string holdback_model_line = 7
-      [(google.api.resource_reference).type = "halo.wfanet.org/ModelLine"];
+  string holdback_model_line = 7 [
+    (google.api.resource_reference).type = "halo.wfanet.org/ModelLine",
+    deprecated = true
+  ];
 
   // When the 'ModelLine' was created.
   google.protobuf.Timestamp create_time = 8

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_lines_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_lines_service.proto
@@ -49,13 +49,20 @@ service ModelLines {
   // (-- api-linter: core::0134::synonyms=disabled
   //     aip.dev/not-precedent: This is not a standard Update method. --)
   rpc SetModelLineHoldbackModelLine(SetModelLineHoldbackModelLineRequest)
-      returns (ModelLine);
+      returns (ModelLine) {
+    option deprecated = true;
+  }
 
   // Sets the `active_end_time` for a `ModelLine`.
   // (-- api-linter: core::0134::synonyms=disabled
   //     aip.dev/not-precedent: This is not a standard Update method. --)
   rpc SetModelLineActiveEndTime(SetModelLineActiveEndTimeRequest)
       returns (ModelLine);
+
+  // Sets the [type][ModelLine.type] field of a [ModelLine][].
+  // (-- api-linter: core::0134::synonyms=disabled
+  //     aip.dev/not-precedent: This is not a standard Update method. --)
+  rpc SetModelLineType(SetModelLineTypeRequest) returns (ModelLine);
 
   // Enumerates the [ModelLine][]s which are available across all specified
   // [DataProvider][]s for the specified time interval.
@@ -155,10 +162,10 @@ message SetModelLineHoldbackModelLineRequest {
   ];
 
   // The holdback model line resource name.
-  string holdback_model_line = 2 [
-    (google.api.resource_reference).type = "halo.wfanet.org/ModelLine",
-    (google.api.field_behavior) = REQUIRED
-  ];
+  //
+  // If not specified, the field will be cleared.
+  string holdback_model_line = 2
+      [(google.api.resource_reference).type = "halo.wfanet.org/ModelLine"];
 }
 
 // Request message for `SetModelLineActiveEndTime` method.
@@ -171,6 +178,20 @@ message SetModelLineActiveEndTimeRequest {
 
   // The active_end_time value to be set.
   google.protobuf.Timestamp active_end_time = 2;
+}
+
+// Request message for the [ModelLines.SetModelLineType][] method.
+message SetModelLineTypeRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.resource_reference).type = "halo.wfanet.org/ModelLine",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // Type value to be set.
+  //
+  // The deprecated [HOLDBACK][ModelLine.Type.HOLDBACK] type may not be used.
+  ModelLine.Type type = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for `EnumerateValidModelLines` method.


### PR DESCRIPTION
Issue: world-federation-of-advertisers/cross-media-measurement#3213