### PR TITLE
feat: Add BigQuery Authorized View steps to ExchangeWorkflow

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -270,6 +270,7 @@ proto_library(
     srcs = ["exchange_workflow.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:any_proto",

--- a/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/exchange_workflow.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/any.proto";
 import "google/type/date.proto";
@@ -178,8 +179,20 @@ message ExchangeWorkflow {
     // serialization of the `Certificate` resource.
     message GenerateCertificateStep {}
 
-    // Preprocesses data for later use by ExecutePrivateMembershipQueriesStep
-    message PreprocessEventsStep {}
+    // Preprocesses events for use in the selected exchange workflow.
+    message PreprocessEventsStep {
+      // The protocol to use for preprocessing events.
+      enum PreprocessProtocol {
+        // Unspecified preprocessor protocol.
+        PREPROCESSOR_PROTOCOL_UNSPECIFIED = 0;
+        // Indicates events should be preprocessed for Private Membership.
+        PRIVATE_MEMBERSHIP = 1;
+        // Indicates events should be preprocessed for Authorized View.
+        AUTHORIZED_VIEW = 2;
+      }
+      // The type of preprocessor to use.
+      PreprocessProtocol protocol = 1 [(google.api.field_behavior) = REQUIRED];
+    }
 
     // Copies a blob from a previous exchange into this one. Requires a single
     // output label "output".
@@ -213,6 +226,80 @@ message ExchangeWorkflow {
     // Assigns JoinKey Ids
     message AssignJoinKeyIdsStep {}
 
+    // Reads encrypted events from BigQuery authorized views.
+    message ReadEncryptedEventsFromBigQueryStep {
+      // BigQuery project ID.
+      string project_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+      // BigQuery dataset ID.
+      string dataset_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+      // BigQuery table or view name.
+      string table_or_view_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+      // Column name for encrypted join key.
+      // Defaults to "encrypted_join_key" if not specified.
+      string key_column_name = 4 [(google.api.field_behavior) = OPTIONAL];
+
+      // Column name for encrypted event data.
+      // Defaults to "encrypted_event_data" if not specified.
+      string event_data_column_name = 5
+          [(google.api.field_behavior) = OPTIONAL];
+
+      // Column name for exchange date.
+      // Defaults to "exchange_date" if not specified.
+      string date_column_name = 6 [(google.api.field_behavior) = OPTIONAL];
+    }
+
+    // Decrypts matched events from BigQuery authorized view and outputs
+    // KeyedDecryptedEventDataSet format.
+    message DecryptAndMatchEventsStep {}
+
+    // Writes encrypted join keys to BigQuery using streaming API.
+    message WriteKeysToBigQueryStep {
+      // BigQuery project ID.
+      string project_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+      // BigQuery dataset ID.
+      string dataset_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+      // BigQuery table name for keys.
+      string table_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+      // Column name for encrypted join key.
+      // Defaults to "encrypted_join_key" if not specified.
+      string key_column_name = 4 [(google.api.field_behavior) = OPTIONAL];
+
+      // Column name for exchange date.
+      // Defaults to "exchange_date" if not specified.
+      string date_column_name = 5 [(google.api.field_behavior) = OPTIONAL];
+    }
+
+    // Writes encrypted events to BigQuery using streaming API.
+    message WriteEventsToBigQueryStep {
+      // BigQuery project ID.
+      string project_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+      // BigQuery dataset ID.
+      string dataset_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+      // BigQuery table name for events.
+      string table_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+      // Column name for encrypted join key.
+      // Defaults to "encrypted_join_key" if not specified.
+      string key_column_name = 4 [(google.api.field_behavior) = OPTIONAL];
+
+      // Column name for encrypted event data.
+      // Defaults to "encrypted_event_data" if not specified.
+      string event_data_column_name = 5
+          [(google.api.field_behavior) = OPTIONAL];
+
+      // Column name for exchange date.
+      // Defaults to "exchange_date" if not specified.
+      string date_column_name = 6 [(google.api.field_behavior) = OPTIONAL];
+    }
+
     oneof step {
       CopyFromSharedStorageStep copy_from_shared_storage_step = 5;
       CopyToSharedStorageStep copy_to_shared_storage_step = 6;
@@ -244,6 +331,11 @@ message ExchangeWorkflow {
           generate_hybrid_encryption_key_pair_step = 23;
       GenerateRandomBytesStep generate_random_bytes_step = 24;
       AssignJoinKeyIdsStep assign_join_key_ids_step = 25;
+      ReadEncryptedEventsFromBigQueryStep
+          read_encrypted_events_from_big_query_step = 26;
+      DecryptAndMatchEventsStep decrypt_and_match_events_step = 27;
+      WriteKeysToBigQueryStep write_keys_to_big_query_step = 28;
+      WriteEventsToBigQueryStep write_events_to_big_query_step = 29;
     }
   }
 


### PR DESCRIPTION
 This change introduces new steps to the ExchangeWorkflow proto to support reading from and writing to
  BigQuery, specifically for the Authorized View panel exchange.

  New Steps Added:

   * ReadEncryptedEventsFromBigQueryStep: Reads encrypted events from a specified BigQuery table or view.
   * DecryptAndMatchEventsStep: Decrypts events read from BigQuery.
   * WriteKeysToBigQueryStep: Writes encrypted join keys to a BigQuery table.
   * WriteEventsToBigQueryStep: Writes encrypted event data to a BigQuery table.

  Additionally, the PreprocessEventsStep has been updated to include a PreprocessProtocol enum to distinguish
  between PRIVATE_MEMBERSHIP and AUTHORIZED_VIEW preprocessing.

  Issue: #261