### PR TITLE
feat: add data availability intersects filter to ListEventGroupsRequest

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -625,6 +625,7 @@ proto_library(
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -20,6 +20,7 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/api/v2alpha/date_interval.proto";
 import "wfa/measurement/api/v2alpha/event_group.proto";
 import "wfa/measurement/api/v2alpha/media_type.proto";
@@ -228,6 +229,10 @@ message ListEventGroupsRequest {
     // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
     // must be on or after.
     google.protobuf.Timestamp data_availability_end_time_on_or_after = 8;
+    // Interval that must be intersected by
+    // [EventGroup.data_availability_interval.start_time][google.type.Interval.start_time]
+    // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
+    google.type.Interval data_availability_intersects = 10;
     // Query for text search on string fields in
     // [EventGroup.event_group_metadata][].
     string metadata_search_query = 5;


### PR DESCRIPTION
Added data_availability_intersects filter to ListEventGroupsRequest in order to filter for EventGroups whose data availability intersects a given range