### PR TITLE
fix: Rename EventGroupActivityService to EventGroupActivities

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -28,7 +28,7 @@ option java_outer_classname = "EventGroupActivitiesServiceProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
 // Service for interacting with `EventGroupActivity` resources.
-service EventGroupActivityService {
+service EventGroupActivities {
   // Batch creates or updates `EventGroupActivities`. Results in an error if any
   // of the specified `EventGroupActivity`s fail to be updated.
   rpc BatchUpdateEventGroupActivities(BatchUpdateEventGroupActivitiesRequest)


### PR DESCRIPTION
Issue: world-federation-of-advertisers/cross-media-measurement#3552