### PR TITLE
feat: add TrusTeeMethodology to Measurement.Result

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -181,6 +181,9 @@ message Measurement {
 
         // Honest Majority Share Shuffle methodology.
         HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 8;
+
+        // TrusTEE methodology.
+        TrusTeeMethodology trus_tee = 9;
       }
     }
     // The reach result.
@@ -222,6 +225,9 @@ message Measurement {
 
         // Honest Majority Share Shuffle methodology.
         HonestMajorityShareShuffleMethodology honest_majority_share_shuffle = 7;
+
+        // TrusTEE methodology.
+        TrusTeeMethodology trus_tee = 8;
       }
     }
     // The frequency result.

--- a/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/multi_party_computation.proto
@@ -34,3 +34,9 @@ message HonestMajorityShareShuffleMethodology {
   // The size of the sampled frequency vector. REQUIRED.
   int64 frequency_vector_size = 1 [(google.api.field_behavior) = REQUIRED];
 }
+
+// Configuration for the TrusTEE methodology.
+message TrusTeeMethodology {
+  // The size of the sampled frequency vector. REQUIRED.
+  int64 frequency_vector_size = 1 [(google.api.field_behavior) = REQUIRED];
+}


### PR DESCRIPTION
Add TrusTeeMethodology message to multi_party_computation.proto (parallel to HonestMajorityShareShuffleMethodology) and add trus_tee fields to the methodology oneofs in both Measurement.Result.Reach and Measurement.Result.Frequency in measurement.proto.

  This allows the Duchy to report frequency_vector_size in the TrusTee measurement result, which downstream consumers (e.g. the Reporting Server) need for variance computation. Previously there was no TrusTee field in the result methodology oneofs, so the Reporting Server had to fall back to TrusTee.getDefaultInstance() with no data.