### PR TITLE
feat: Add support for EventGroup hierarchies

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -159,7 +159,9 @@ proto_library(
     srcs = ["event_group_metadata.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        "//src/main/proto/wfa/measurement/type:future_disposition_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_protobuf//:struct_proto",
     ],
 )
 
@@ -180,6 +182,17 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_protobuf//:descriptor_proto",
+    ],
+)
+
+proto_library(
+    name = "event_group_chain_proto",
+    srcs = ["event_group_chain.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":event_group_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -60,8 +60,9 @@ message EventGroup {
 
   // ID referencing the `EventGroup` in an external system, provided by the
   // `DataProvider`. This value should be used to help the `DataProvider`
-  // synchronize their metadata with the EventGroupsService. See
-  // `EventGroupMetadata` which provides a set of identifiers with better
+  // synchronize their metadata with the EventGroupsService.
+  //
+  // See [entity_key][] which provides a set of identifiers with better
   // defined semantics.
   string event_group_reference_id = 5;
 
@@ -214,5 +215,56 @@ message EventGroup {
   //
   // Only set when the view is `WITH_ACTIVITY_SUMMARY`.
   repeated AggregatedActivity aggregated_activities = 15
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Key of the entity in the [DataProvider][]'s system that an [EventGroup][]
+  // represents.
+  message EntityKey {
+    // Type of the entity in the [DataProvider][]'s system.
+    //
+    // This must be a URL-safe string, such that URL-encoding or -decoding
+    // results in the same string.
+    string entity_type = 1 [(type.future_disposition) = REQUIRED];
+    // ID of the entity in the [DataProvider][]'s system.
+    //
+    // This should be an ID that is available to [MeasurementConsumer][]'s
+    // through the [DataProvider][]'s system.
+    //
+    // This must be a URL-safe string, such that URL-encoding or -decoding
+    // results in the same string.
+    string entity_id = 2 [(type.future_disposition) = REQUIRED];
+  }
+  // Entity in the [DataProvider][]'s system that this [EventGroup][]
+  // represents.
+  //
+  // Once specified, this may not change.
+  EntityKey entity_key = 16 [(type.future_disposition) = REQUIRED];
+
+  // Resource name of the parent [EventGroup][].
+  //
+  // The referenced [EventGroup][] must belong to to the same parent
+  // [DataProvider][] and [MeasurementConsumer][] as this one.
+  //
+  // If no [EventGroup][] has this one as its [EventGroup.parent_event_group][]
+  // it is a leaf. Any [DataProvider][] event must belong to no more than one
+  // leaf [EventGroup][] for its parent [MeasurementConsumer][].
+  //
+  // If specified, [entity_key][] is required for both this [EventGroup][] and
+  // the parent. Furthermore, the parent's [EntityKey.entity_type][] must differ
+  // from that of all of its descendants.
+  //
+  // (-- api-linter: core::0121::no-mutable-cycles=disabled
+  //     aip.dev/not-precedent: Cycles cannot be formed. --)
+  string parent_event_group = 17
+      [(google.api.resource_reference).type = "halo.wfanet.org/EventGroup"];
+
+  // Path from the root [EventGroup][] to this one.
+  //
+  // This is equivalent of appending [entity_key][] to  the [entity_path][]
+  // field of [parent_event_group][].
+  //
+  // This must be unique across all [EventGroup][]s for the parent
+  // ([DataProvider][], [MeasurementConsumer][]) pair.
+  repeated EntityKey entity_path = 18
       [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_chain.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_chain.proto
@@ -1,0 +1,54 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.api.v2alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "wfa/measurement/api/v2alpha/event_group.proto";
+
+option java_package = "org.wfanet.measurement.api.v2alpha";
+option java_multiple_files = true;
+option java_outer_classname = "EventGroupChainProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
+
+// Pseudo-resource representing a chain of [EventGroup][]s from root to leaf.
+message EventGroupChain {
+  option (google.api.resource) = {
+    type: "halo.wfanet.org/EventGroupChain"
+    pattern: "dataProviders/{data_provider}/eventGroupChains/{event_group_chain}"
+    pattern: "measurementConsumers/{measurement_consumer}/eventGroupChains/{event_group_chain}"
+    singular: "eventGroupChain"
+    plural: "eventGroupChains"
+  };
+
+  // Resource name.
+  //
+  // The resource ID is the same as that of the leaf [EventGroup][].
+  //
+  // Canonical format:
+  // dataProviders/{data_provider}/eventGroupChains/{event_group_chain}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // Chain of [EventGroup][]'s where the [EventGroup][] at index `n` is the
+  // parent of the [EventGroup][] at index `n + 1`.
+  //
+  // (-- api-linter: core::0122::embedded-resource=disabled
+  //     aip.dev/not-precedent: This is providing denormalization. --)
+  repeated EventGroup event_groups = 2;
+
+  // TODO: Consider adding a merged entity metadata field for convenience.
+}

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata.proto
@@ -17,6 +17,8 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
+import "google/protobuf/struct.proto";
+import "wfa/measurement/type/future_disposition.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -50,4 +52,11 @@ message EventGroupMetadata {
     // Metadata for an [EventGroup][] containing ad impression events.
     AdMetadata ad_metadata = 2;
   }
+
+  // Metadata for the entity that the [EventGroup][] represents.
+  //
+  // The schema is specific to the ([DataProvider][],
+  // [EventGroup.EntityType][]) pair.
+  google.protobuf.Struct entity_metadata = 3
+      [(type.future_disposition) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -241,6 +241,12 @@ message ListEventGroupsRequest {
     // [EventGroup][]. [start_date][DateInterval.start_date] and
     // [end_date][DateInterval.end_date] are required.
     DateInterval activity_contains = 9;
+    // Set of [EventGroup.EntityType][] values which
+    // [EventGroup.EntityKey.type][] of [EventGroup.entity_key][] must be in.
+    //
+    // If unspecified, the server will treat this as if it contains
+    // [EventGroup.EntityType.CAMPAIGN][].
+    repeated EventGroup.EntityType entity_type_in = 11;
   }
   // Filter criteria for this request.
   //


### PR DESCRIPTION
The new EventGroupChain pseudo-resource provides a denormalized view of a leaf EventGroup and its parents. This can make integrations more convenient, for example creating a whole chain of EventGroups at once.

## Corresponding methods (TODO)

* LookupEventGroup - Looks up an EventGroup by its entity path
  * Could alternatively just add an entity path filter to ListEventGroups.
* CreateEventGroupChain - Creates a new chain, specifically a new leaf.
  * Any non-existent ancestors will also be created.
* UpdateEventGroupChain - Updates all EventGroups in a chain.
  * Any non-existent ancestors will be created. This cannot be used to add a new leaf.
* LookupEventGroupChain - Looks up a chain by its entity path (entity keys from root to leaf).

The EventGroupChain mutators could rely on the entity key rather than the name, so you need not know if an ancestor EventGroup already exists. This means it can fill in the `parent_event_group` fields for you based on the order of the specified EventGroups.

## Caveats

* The EventGroupChain design precludes adding support for multiple parents, since it relies on uniquely identifying a chain by the leaf EventGroup.

## Phased rollout

* The default value of the `entity_type_in` filter field for ListEventGroups ensures backwards-compatibility for existing clients.
* A given Halo instance (Kingdom) would have an option (flag) indicating what entity types it supports. This defaults to CAMPAIGN for backwards compatibility with existing EventGroups.
  * It is an error to create an EventGroup with an unsupported type.
  * Due to the restriction requiring each EventGroup in a chain to have a unique entity type, this inherently means that hierarchical EventGroups are not supported until a Kingdom supports more than one entity type.
  * The operator should only update this once its UI supports a given entity type. It is an error to remove an entity type from the option once an EventGroup has been created with that type.