### PR TITLE
feat: Support more granular EventGroups

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -159,7 +159,9 @@ proto_library(
     srcs = ["event_group_metadata.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        "//src/main/proto/wfa/measurement/type:future_disposition_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_protobuf//:struct_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group.proto
@@ -60,8 +60,9 @@ message EventGroup {
 
   // ID referencing the `EventGroup` in an external system, provided by the
   // `DataProvider`. This value should be used to help the `DataProvider`
-  // synchronize their metadata with the EventGroupsService. See
-  // `EventGroupMetadata` which provides a set of identifiers with better
+  // synchronize their metadata with the EventGroupsService.
+  //
+  // See [entity_key][] which provides a set of identifiers with better
   // defined semantics.
   string event_group_reference_id = 5;
 
@@ -215,4 +216,30 @@ message EventGroup {
   // Only set when the view is `WITH_ACTIVITY_SUMMARY`.
   repeated AggregatedActivity aggregated_activities = 15
       [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Key of the entity in the [DataProvider][]'s system that an [EventGroup][]
+  // represents.
+  message EntityKey {
+    // Type of the entity in the [DataProvider][]'s system as a human- and
+    // machine-readable string.
+    //
+    // This must be a URL-safe string, such that URL-encoding or -decoding
+    // results in the same string.
+    string entity_type = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // ID of the entity in the [DataProvider][]'s system.
+    //
+    // This should be an ID that is available to [MeasurementConsumer][]'s
+    // through the [DataProvider][]'s system.
+    //
+    // This must be a URL-safe string, such that URL-encoding or -decoding
+    // results in the same string.
+    string entity_id = 2 [(type.future_disposition) = REQUIRED];
+  }
+  // Entity in the [DataProvider][]'s system that this [EventGroup][]
+  // represents.
+  //
+  // If specified, this must be unique across all [EventGroup][]s for the
+  // parent ([DataProvider][], [MeasurementConsumer][]) pair.
+  EntityKey entity_key = 16 [(type.future_disposition) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata.proto
@@ -17,6 +17,8 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
+import "google/protobuf/struct.proto";
+import "wfa/measurement/type/future_disposition.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -50,4 +52,11 @@ message EventGroupMetadata {
     // Metadata for an [EventGroup][] containing ad impression events.
     AdMetadata ad_metadata = 2;
   }
+
+  // Metadata for the entity that the [EventGroup][] represents.
+  //
+  // The schema is specific to the ([DataProvider][],
+  // [EventGroup.EntityKey.entity_type][]) pair.
+  google.protobuf.Struct entity_metadata = 3
+      [(type.future_disposition) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_groups_service.proto
@@ -241,6 +241,11 @@ message ListEventGroupsRequest {
     // [EventGroup][]. [start_date][DateInterval.start_date] and
     // [end_date][DateInterval.end_date] are required.
     DateInterval activity_contains = 9;
+    // Set of entity types which [EventGroup.EntityKey.type][] of
+    // [EventGroup.entity_key][] must be in.
+    //
+    // If unspecified, the server will treat this as if it contains "campaign".
+    repeated string entity_type_in = 11;
   }
   // Filter criteria for this request.
   //


### PR DESCRIPTION
## Phased rollout

* All existing `EventGroup`s will have an `entity_type` of "campaign" for backwards compatibility.
  * This corresponds to the default value of the `entity_type_in` filter field in `ListEventGroups`.
* New granular `EventGroup`s will be created with an `entity_type` other than "campaign" and have `EventGroupMetadata.entity_metadata` specified.

## Potential future features

* Filters for `EventGroupMetadata.entity_metadata` in `ListEventGroups`.
* Representing the relationship between `EventGroup`s at different levels of granularity as a hierarchy.

Issue: world-federation-of-advertisers/cross-media-measurement#3697