### PR TITLE
docs: clarify freq-1 bucket threshold behavior in histogram

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -233,11 +233,6 @@ message ProtocolConfig {
     //   - Reach: The noised reach is released only if it meets
     //     `min_users`. Otherwise, zero reach is returned.
     //
-    //   - Impression count: The noised impression count is released only
-    //     if it meets both `min_users` (total unique users) and
-    //     `min_impressions` (total impressions). Otherwise, zero is
-    //     returned.
-    //
     //   - Frequency histogram: Both `min_users` and `min_impressions`
     //     are checked for each frequency bucket. For a bucket at
     //     frequency f with n users, the impression count is n * f;

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -243,9 +243,12 @@ message ProtocolConfig {
     //     added to the next lower bucket (e.g. 11+, which becomes the
     //     new top bucket) and that bucket is re-evaluated. This repeats
     //     until all remaining buckets meet both thresholds. Folded
-    //     buckets are reported as zero. If the 1+ bucket does not meet
-    //     the thresholds, the entire histogram is zeroed out and reach
-    //     is also reported as zero.
+    //     buckets are reported as zero. If the lowest bucket (frequency
+    //     1) does not meet the thresholds, it is zeroed like any other
+    //     bucket; however, because there is no lower bucket to fold
+    //     into, its user count is simply dropped. Higher-frequency
+    //     buckets that independently meet the thresholds are still
+    //     reported.
     //
     // These thresholds serve two purposes:
     //   1. Small-cell suppression for privacy. Requiring at least

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -233,6 +233,11 @@ message ProtocolConfig {
     //   - Reach: The noised reach is released only if it meets
     //     `min_users`. Otherwise, zero reach is returned.
     //
+    //   - Impression count: The noised impression count is released only
+    //     if it meets both `min_users` (total unique users) and
+    //     `min_impressions` (total impressions). Otherwise, zero is
+    //     returned.
+    //
     //   - Frequency histogram: Both `min_users` and `min_impressions`
     //     are checked for each frequency bucket. For a bucket at
     //     frequency f with n users, the impression count is n * f;
@@ -242,8 +247,11 @@ message ProtocolConfig {
     //     (e.g. 12+) does not meet either threshold, its user count is
     //     added to the next lower bucket (e.g. 11+, which becomes the
     //     new top bucket) and that bucket is re-evaluated. This repeats
-    //     until all remaining buckets meet both thresholds. Folded
-    //     buckets are reported as zero. If the lowest bucket (frequency
+    //     until all remaining buckets meet both thresholds.
+    //     When users fold from frequency f to f-1, the impressions
+    //     threshold on the receiving bucket evaluates them at frequency
+    //     f-1, not their original frequency. Folded buckets are
+    //     reported as zero. If the lowest bucket (frequency
     //     1) does not meet the thresholds, it is zeroed like any other
     //     bucket; however, because there is no lower bucket to fold
     //     into, its user count is simply dropped. Higher-frequency


### PR DESCRIPTION
## Summary

- Clarify that when the lowest frequency bucket (freq-1) fails the small-cell suppression threshold, only that bucket is zeroed — higher-frequency buckets that independently meet the thresholds are still reported.
- The previous wording incorrectly stated that the entire histogram is zeroed when the 1+ bucket fails.

## Test plan

- [x] No code changes — proto comment update only

Issue: world-federation-of-advertisers/cross-media-measurement#3651