### PR TITLE
feat: add memoization flag to model shard

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
@@ -62,7 +62,8 @@ message ModelShard {
   ];
 
   // Whether memoized VID assignment is enabled for this `ModelShard`.
-  bool memoized_vid_assignment_enabled = 4;
+  bool memoized_vid_assignment_enabled = 4
+      [(google.api.field_behavior) = IMMUTABLE];
 
   // When the 'ModelShard' was created.
   google.protobuf.Timestamp create_time = 5

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
@@ -61,7 +61,9 @@ message ModelShard {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // Whether memoized VID assignment is enabled for this `ModelShard`.
+  // If true, the EDP Aggregator must run pool assignment (Phase 0)
+  // and rank allocation (Phase 1) before VID labeling for impressions
+  // associated with this `ModelShard`.
   bool memoized_vid_assignment_enabled = 4
       [(google.api.field_behavior) = IMMUTABLE];
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/model_shard.proto
@@ -61,6 +61,9 @@ message ModelShard {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
+  // Whether memoized VID assignment is enabled for this `ModelShard`.
+  bool memoized_vid_assignment_enabled = 4;
+
   // When the 'ModelShard' was created.
   google.protobuf.Timestamp create_time = 5
       [(google.api.field_behavior) = OUTPUT_ONLY];


### PR DESCRIPTION
## Summary
Adds a new `memoized_vid_assignment_enabled` boolean field to the `ModelShard` resource message in the v2alpha API.
## Changes
- Added `bool memoized_vid_assignment_enabled = 4` to the `ModelShard` message in `model_shard.proto`, indicating whether memoized VID assignment is enabled for a given `ModelShard`.
- No changes required in `model_shards_service.proto`: it embeds the `ModelShard` message directly in its request/response types (`CreateModelShardRequest`, `ListModelShardsResponse`, etc.), so the new field is automatically exposed across all RPCs.
## Details
- Uses field number `4`, which was previously unused (`model_blob` is `3`, `create_time` is `5`).
- Field is a standard mutable field (no `field_behavior` annotation), so it can be set on `CreateModelShard` and is returned on reads. Naming and the "Whether ..." doc comment follow the existing convention (e.g. the `DataProvider.Capabilities` flags).

Issue: world-federation-of-advertisers/cross-media-measurement#3902