### PR TITLE
feat: add ListEventGroupActivities RPC to EventGroupActivities service

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -641,6 +641,7 @@ proto_library(
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:empty_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -637,11 +637,11 @@ proto_library(
     srcs = ["event_group_activities_service.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":date_interval_proto",
         ":event_group_activity_proto",
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
-        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:empty_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -163,9 +163,12 @@ message ListEventGroupActivitiesRequest {
     // Resource names of `EventGroup`s to filter to. If empty, returns
     // activities across all `EventGroup`s for the `DataProvider`.
     repeated string event_groups = 2
-        [(google.api.resource_reference).type =
-             "halo.wfanet.org/EventGroup" ];
+        [(google.api.resource_reference).type = "halo.wfanet.org/EventGroup"];
   }
+  // Filter criteria for this request.
+  //
+  // (-- api-linter: core::0132::request-field-types=disabled
+  //     aip.dev/not-precedent: This API uses structured filters. --)
   Filter filter = 4;
 }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -61,7 +61,7 @@ message DeleteEventGroupActivityRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type : "halo.wfanet.org/EventGroupActivity"
+      type: "halo.wfanet.org/EventGroupActivity"
     }
   ];
 }
@@ -72,7 +72,7 @@ message DeleteEventGroupActivityRequest {
 message UpdateEventGroupActivityRequest {
   // Resource
   EventGroupActivity event_group_activity = 1
-      [ (google.api.field_behavior) = REQUIRED ];
+      [(google.api.field_behavior) = REQUIRED];
 
   // If set to true, and the event group activity is not found, a new event
   // group activity will be created.
@@ -87,14 +87,14 @@ message BatchUpdateEventGroupActivitiesRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type : "halo.wfanet.org/EventGroupActivity"
+      child_type: "halo.wfanet.org/EventGroupActivity"
     }
   ];
 
   // The requests for updating EventGroupActivities.
   // A maximum of 1000 EventGroupActivities can be updated in a batch.
   repeated UpdateEventGroupActivityRequest requests = 2
-      [ (google.api.field_behavior) = REQUIRED ];
+      [(google.api.field_behavior) = REQUIRED];
 }
 
 // Response message for BatchUpdateEventGroupActivities method.
@@ -110,7 +110,7 @@ message BatchDeleteEventGroupActivitiesRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type : "edpaggregator.halo-cmm.org/EventGroupActivity"
+      child_type: "edpaggregator.halo-cmm.org/EventGroupActivity"
     }
   ];
 
@@ -118,7 +118,7 @@ message BatchDeleteEventGroupActivitiesRequest {
   repeated string names = 2 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type : "edpaggregator.halo-cmm.org/EventGroupActivity"
+      type: "edpaggregator.halo-cmm.org/EventGroupActivity"
     }
   ];
 }
@@ -130,7 +130,7 @@ message ListEventGroupActivitiesRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type : "halo.wfanet.org/EventGroupActivity"
+      child_type: "halo.wfanet.org/EventGroupActivity"
     }
   ];
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -126,13 +126,15 @@ message BatchDeleteEventGroupActivitiesRequest {
 
 // Request message for `ListEventGroupActivities` method.
 message ListEventGroupActivitiesRequest {
-  // The parent `DataProvider` resource name.
-  // Format: dataProviders/{data_provider}
+  // Resource name of the parent `EventGroup`.
+  //
+  // The wildcard ID (`-`) may be used in place of the `EventGroup` ID to list
+  // across every `EventGroup` in the ancestor `DataProvider`. If this is done,
+  // then the wildcard ID may also be used in place of the `DataProvider` ID to
+  // list across all ancestors.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      child_type: "halo.wfanet.org/EventGroupActivity"
-    }
+    (google.api.resource_reference).type = "halo.wfanet.org/EventGroup"
   ];
 
   // The maximum number of resources to return. The service may return fewer
@@ -160,10 +162,6 @@ message ListEventGroupActivitiesRequest {
     // Filter by activity date range. Only activities with dates within
     // this interval are returned.
     DateInterval date_interval = 1;
-    // Resource names of `EventGroup`s to filter to. If empty, returns
-    // activities across all `EventGroup`s for the `DataProvider`.
-    repeated string event_groups = 2
-        [(google.api.resource_reference).type = "halo.wfanet.org/EventGroup"];
   }
   // Filter criteria for this request.
   //

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -20,7 +20,7 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/empty.proto";
-import "google/type/interval.proto";
+import "wfa/measurement/api/v2alpha/date_interval.proto";
 import "wfa/measurement/api/v2alpha/event_group_activity.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -159,7 +159,7 @@ message ListEventGroupActivitiesRequest {
   message Filter {
     // Filter by activity date range. Only activities with dates within
     // this interval are returned.
-    google.type.Interval date_interval = 1;
+    DateInterval date_interval = 1;
     // Resource names of `EventGroup`s to filter to. If empty, returns
     // activities across all `EventGroup`s for the `DataProvider`.
     repeated string event_groups = 2

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -20,6 +20,7 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/empty.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/api/v2alpha/event_group_activity.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -110,7 +111,7 @@ message BatchDeleteEventGroupActivitiesRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "edpaggregator.halo-cmm.org/EventGroupActivity"
+      child_type: "halo.wfanet.org/EventGroupActivity"
     }
   ];
 
@@ -118,15 +119,15 @@ message BatchDeleteEventGroupActivitiesRequest {
   repeated string names = 2 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "edpaggregator.halo-cmm.org/EventGroupActivity"
+      type: "halo.wfanet.org/EventGroupActivity"
     }
   ];
 }
 
 // Request message for `ListEventGroupActivities` method.
 message ListEventGroupActivitiesRequest {
-  // The parent EventGroup resource name.
-  // Format: dataProviders/{data_provider}/eventGroups/{event_group}
+  // The parent `DataProvider` resource name.
+  // Format: dataProviders/{data_provider}
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -147,6 +148,25 @@ message ListEventGroupActivitiesRequest {
   // `ListEventGroupActivities` must match the call that provided the page
   // token.
   string page_token = 3;
+
+  // Structured filter criteria.
+  //
+  // Each field represents a term in a conjunction. If a field is not
+  // specified, its value is not considered as part of the criteria.
+  // (-- api-linter: core::0132::request-unknown-fields=disabled
+  //     aip.dev/not-precedent: Using structured filter instead of
+  //     AIP-160. --)
+  message Filter {
+    // Filter by activity date range. Only activities with dates within
+    // this interval are returned.
+    google.type.Interval date_interval = 1;
+    // Resource names of `EventGroup`s to filter to. If empty, returns
+    // activities across all `EventGroup`s for the `DataProvider`.
+    repeated string event_groups = 2
+        [(google.api.resource_reference).type =
+             "halo.wfanet.org/EventGroup" ];
+  }
+  Filter filter = 4;
 }
 
 // Response message for `ListEventGroupActivities` method.

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -47,6 +47,12 @@ service EventGroupActivities {
   // specified `EventGroupActivity`s fail to be updated.
   rpc BatchDeleteEventGroupActivities(BatchDeleteEventGroupActivitiesRequest)
       returns (google.protobuf.Empty) {}
+
+  // Lists `EventGroupActivity` resources for a given `EventGroup`.
+  rpc ListEventGroupActivities(ListEventGroupActivitiesRequest)
+      returns (ListEventGroupActivitiesResponse) {
+    option (google.api.method_signature) = "parent";
+  }
 }
 
 // Request message for `DeleteEventGroupActivity` method.
@@ -55,7 +61,7 @@ message DeleteEventGroupActivityRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "halo.wfanet.org/EventGroupActivity"
+      type : "halo.wfanet.org/EventGroupActivity"
     }
   ];
 }
@@ -66,7 +72,7 @@ message DeleteEventGroupActivityRequest {
 message UpdateEventGroupActivityRequest {
   // Resource
   EventGroupActivity event_group_activity = 1
-      [(google.api.field_behavior) = REQUIRED];
+      [ (google.api.field_behavior) = REQUIRED ];
 
   // If set to true, and the event group activity is not found, a new event
   // group activity will be created.
@@ -81,14 +87,14 @@ message BatchUpdateEventGroupActivitiesRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "halo.wfanet.org/EventGroupActivity"
+      child_type : "halo.wfanet.org/EventGroupActivity"
     }
   ];
 
   // The requests for updating EventGroupActivities.
   // A maximum of 1000 EventGroupActivities can be updated in a batch.
   repeated UpdateEventGroupActivityRequest requests = 2
-      [(google.api.field_behavior) = REQUIRED];
+      [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // Response message for BatchUpdateEventGroupActivities method.
@@ -104,7 +110,7 @@ message BatchDeleteEventGroupActivitiesRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "edpaggregator.halo-cmm.org/EventGroupActivity"
+      child_type : "edpaggregator.halo-cmm.org/EventGroupActivity"
     }
   ];
 
@@ -112,7 +118,43 @@ message BatchDeleteEventGroupActivitiesRequest {
   repeated string names = 2 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "edpaggregator.halo-cmm.org/EventGroupActivity"
+      type : "edpaggregator.halo-cmm.org/EventGroupActivity"
     }
   ];
+}
+
+// Request message for `ListEventGroupActivities` method.
+message ListEventGroupActivitiesRequest {
+  // The parent EventGroup resource name.
+  // Format: dataProviders/{data_provider}/eventGroups/{event_group}
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type : "halo.wfanet.org/EventGroupActivity"
+    }
+  ];
+
+  // The maximum number of resources to return. The service may return fewer
+  // than this value.
+  // If unspecified, at most 1000 resources will be returned.
+  // The maximum value is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListEventGroupActivities` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to
+  // `ListEventGroupActivities` must match the call that provided the page
+  // token.
+  string page_token = 3;
+}
+
+// Response message for `ListEventGroupActivities` method.
+message ListEventGroupActivitiesResponse {
+  // The `EventGroupActivity` resources.
+  repeated EventGroupActivity event_group_activities = 1;
+
+  // A token that can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
 }


### PR DESCRIPTION
Add ListEventGroupActivities RPC (AIP-132) to the EventGroupActivities service with structured Filter for date_interval and event_groups. Fix BatchDeleteEventGroupActivities resource references.

Issue: world-federation-of-advertisers/cross-media-measurement-api#282