### PR TITLE
docs: remove DataProvider wildcard support from ListEventGroupActivities comment

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -49,7 +49,8 @@ service EventGroupActivities {
   rpc BatchDeleteEventGroupActivities(BatchDeleteEventGroupActivitiesRequest)
       returns (google.protobuf.Empty) {}
 
-  // Lists `EventGroupActivity` resources for a given `EventGroup`.
+  // Lists `EventGroupActivity` resources for a given `EventGroup`, or across
+  // all `EventGroup`s under a `DataProvider` when the wildcard ID is used.
   rpc ListEventGroupActivities(ListEventGroupActivitiesRequest)
       returns (ListEventGroupActivitiesResponse) {
     option (google.api.method_signature) = "parent";

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -129,9 +129,7 @@ message ListEventGroupActivitiesRequest {
   // Resource name of the parent `EventGroup`.
   //
   // The wildcard ID (`-`) may be used in place of the `EventGroup` ID to list
-  // across every `EventGroup` in the ancestor `DataProvider`. If this is done,
-  // then the wildcard ID may also be used in place of the `DataProvider` ID to
-  // list across all ancestors.
+  // across every `EventGroup` in the ancestor `DataProvider`.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "halo.wfanet.org/EventGroup"


### PR DESCRIPTION
Remove the comment about using wildcard ID for DataProvider in ListEventGroupActivitiesRequest. DataProvider is always required — only EventGroup supports wildcard listing.

Issue: #282