### PR TITLE
docs(event-annotations): media-type inheritance for oneof-member fields

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
@@ -88,7 +88,22 @@ message EventTemplateDescriptor {
   // High-level description of the Event Template.
   string description = 3;
   // The `MediaType` to which this template applies. If a template is not
-  // annotated with a `media_type` then it applies to all `MediaType`s
+  // annotated with a `media_type` then it applies to all `MediaType`s.
+  //
+  // Media-type inheritance for oneof members. Fields nested inside a
+  // `oneof` member of a template are exposed as template fields under the
+  // dotted path `<template>.<member>.<field>`. Their effective `MediaType`
+  // is inherited from the parent template (the message annotated with
+  // `event_template`). If the parent carries no `media_type` annotation,
+  // the inherited value is `MEDIA_TYPE_UNSPECIFIED`, which silently makes
+  // `IMPRESSION_QUALIFICATION`-tagged nested fields unreachable to all
+  // Impression Qualification Filter specs (an IQF requires a matching
+  // non-unspecified `MediaType`).
+  //
+  // Guidance for real EDP schemas: place `IMPRESSION_QUALIFICATION`
+  // annotations on per-mediaType templates (which carry an explicit
+  // `media_type`). Reserve `FILTERABLE` / `GROUPABLE` for nested fields
+  // on cross-mediaType templates.
   MediaType media_type = 4;
 }
 // Descriptor for an Event message type.

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_annotations.proto
@@ -90,20 +90,23 @@ message EventTemplateDescriptor {
   // The `MediaType` to which this template applies. If a template is not
   // annotated with a `media_type` then it applies to all `MediaType`s.
   //
-  // Media-type inheritance for oneof members. Fields nested inside a
-  // `oneof` member of a template are exposed as template fields under the
-  // dotted path `<template>.<member>.<field>`. Their effective `MediaType`
-  // is inherited from the parent template (the message annotated with
-  // `event_template`). If the parent carries no `media_type` annotation,
-  // the inherited value is `MEDIA_TYPE_UNSPECIFIED`, which silently makes
-  // `IMPRESSION_QUALIFICATION`-tagged nested fields unreachable to all
-  // Impression Qualification Filter specs (an IQF requires a matching
-  // non-unspecified `MediaType`).
+  // When a template contains a `oneof`, fields nested inside a member
+  // are exposed as template fields under the dotted path
+  // `<template>.<member>.<field>`. Their effective `MediaType` is
+  // inherited from the parent template (the message annotated with
+  // `event_template`). This matters for `IMPRESSION_QUALIFICATION`:
+  // an IQF requires a matching non-unspecified `MediaType`, so
+  // `IMPRESSION_QUALIFICATION`-tagged nested fields on a template
+  // with no `media_type` (inherited value `MEDIA_TYPE_UNSPECIFIED`)
+  // are unreachable to all IQF specs.
   //
-  // Guidance for real EDP schemas: place `IMPRESSION_QUALIFICATION`
-  // annotations on per-mediaType templates (which carry an explicit
-  // `media_type`). Reserve `FILTERABLE` / `GROUPABLE` for nested fields
-  // on cross-mediaType templates.
+  // `FILTERABLE` and `GROUPABLE` fields are unaffected by
+  // `media_type` -- they work on any template regardless.
+  //
+  // Guidance: place `IMPRESSION_QUALIFICATION` annotations on
+  // per-mediaType templates (which carry an explicit `media_type`).
+  // `FILTERABLE` / `GROUPABLE` may go on any template, including
+  // cross-mediaType templates and their oneof members.
   MediaType media_type = 4;
 }
 // Descriptor for an Event message type.


### PR DESCRIPTION
## Summary

Extend EventTemplateDescriptor.media_type comment with:

- A description of how MediaType is inherited by fields nested inside oneof members (path template.member.field).
- A warning about the failure mode where a parent template with no media_type annotation silently makes IMPRESSION_QUALIFICATION-tagged nested fields unreachable.
- Guidance for real EDP schemas: place IMPRESSION_QUALIFICATION annotations on per-mediaType templates; FILTERABLE / GROUPABLE may go on any template including cross-mediaType templates and their oneof members.

## Why here

Consumer-side details for descent into oneof members live in cross-media-measurement EventMessageDescriptor. Per Sanjay review comment on world-federation-of-advertisers/cross-media-measurement#4152, schema-design guidance belongs in this repo alongside where the event_template and template_field message options are declared, so event-template authors have one canonical reference.

## Follow-up

Once this merges, the corresponding KDoc block in cross-media-measurement EventMessageDescriptor.kt will be trimmed to point at this doc.

Issue: world-federation-of-advertisers/cross-media-measurement#4147
