### PR TITLE
feat: Add DETERMINISTIC_TRUNCATED_LAPLACE noise mechanism

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -99,7 +99,7 @@ message DataProvider {
     bool noise_mechanism_none_supported = 3;
 
     // Whether the DETERMINISTIC_TRUNCATED_LAPLACE noise mechanism is supported.
-    bool deterministic_noise_supported = 4;
+    bool noise_mechanism_deterministic_truncated_laplace_supported = 4;
   }
   // Capabilities of this `DataProvider`, i.e. what this `DataProvider` is both
   // willing and able to support.

--- a/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/data_provider.proto
@@ -97,6 +97,9 @@ message DataProvider {
     //
     // CONTINUOUS_GAUSSIAN is always assumed to be supported.
     bool noise_mechanism_none_supported = 3;
+
+    // Whether the DETERMINISTIC_TRUNCATED_LAPLACE noise mechanism is supported.
+    bool deterministic_noise_supported = 4;
   }
   // Capabilities of this `DataProvider`, i.e. what this `DataProvider` is both
   // willing and able to support.

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -279,11 +279,12 @@ message ProtocolConfig {
     ResultMinimumThresholds result_minimum_thresholds = 2;
 
     // Required when `noise_mechanism` is DETERMINISTIC_TRUNCATED_LAPLACE.
-    DeterministicNoiseParams deterministic_noise_params = 3;
+    DeterministicTruncatedLaplaceNoiseParams
+        deterministic_truncated_laplace_noise_params = 3;
   }
 
   // Parameters for DETERMINISTIC_TRUNCATED_LAPLACE noise.
-  message DeterministicNoiseParams {
+  message DeterministicTruncatedLaplaceNoiseParams {
     // Draws are truncated to `[-truncation_bound, truncation_bound]`.
     int32 truncation_bound = 1;
   }

--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -75,6 +75,8 @@ message ProtocolConfig {
     CONTINUOUS_LAPLACE = 4;
     // Continuous Gaussian.
     CONTINUOUS_GAUSSIAN = 5;
+    // Deterministic truncated Laplace.
+    DETERMINISTIC_TRUNCATED_LAPLACE = 6;
   }
 
   // Configuration for the Liquid Legions v2 R/F protocol.
@@ -275,6 +277,15 @@ message ProtocolConfig {
 
     // Optional minimum thresholds for releasing the result.
     ResultMinimumThresholds result_minimum_thresholds = 2;
+
+    // Required when `noise_mechanism` is DETERMINISTIC_TRUNCATED_LAPLACE.
+    DeterministicNoiseParams deterministic_noise_params = 3;
+  }
+
+  // Parameters for DETERMINISTIC_TRUNCATED_LAPLACE noise.
+  message DeterministicNoiseParams {
+    // Draws are truncated to `[-truncation_bound, truncation_bound]`.
+    int32 truncation_bound = 1;
   }
 
   // Configuration for a specific protocol.


### PR DESCRIPTION
## Summary

Component A of the deterministic-noise workstream. Adds to the public API:
- `NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE`
- `ProtocolConfig.DeterministicNoiseParams` (truncation bound) + `ProtocolConfig.TrusTee.deterministic_noise_params`
- `DataProvider.Capabilities.deterministic_noise_supported`

## Test plan

Proto build passes; api-linter clean on the changed files.

Issue: world-federation-of-advertisers/cross-media-measurement#4182
