### PR TITLE
docs: fix ListEventGroupActivities page_size and parent doc comments

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -138,7 +138,7 @@ message ListEventGroupActivitiesRequest {
 
   // The maximum number of resources to return. The service may return fewer
   // than this value.
-  // If unspecified, at most 1000 resources will be returned.
+  // If unspecified, at most 50 resources will be returned.
   // The maximum value is 1000; values above 1000 will be coerced to 1000.
   int32 page_size = 2;
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_activities_service.proto
@@ -127,10 +127,11 @@ message BatchDeleteEventGroupActivitiesRequest {
 
 // Request message for `ListEventGroupActivities` method.
 message ListEventGroupActivitiesRequest {
-  // Resource name of the parent `EventGroup`.
+  // Resource name of the parent `EventGroup`, either DataProvider-rooted or
+  // MeasurementConsumer-rooted.
   //
-  // The wildcard ID (`-`) may be used in place of the `EventGroup` ID to list
-  // across every `EventGroup` in the ancestor `DataProvider`.
+  // The wildcard ID (`-`) may replace the `EventGroup` ID to list across every
+  // `EventGroup` in the ancestor `DataProvider` or `MeasurementConsumer`.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "halo.wfanet.org/EventGroup"


### PR DESCRIPTION
Fix two stale doc comments on `ListEventGroupActivitiesRequest`:

1. `page_size`: the unspecified default is 50, not 1000 (the service default changed when `ListEventGroupActivities` landed). The `maximum value is 1000` cap is unchanged.
2. `parent`: document that the parent may be DataProvider-rooted or MeasurementConsumer-rooted, with wildcard listing across either ancestor.

Doc-only.

Issue: #288