### PR TITLE
feat: add UnlinkedClientAccount v2alpha resource and service

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -773,3 +773,26 @@ proto_library(
         "@com_google_protobuf//:empty_proto",
     ],
 )
+
+proto_library(
+    name = "unlinked_client_account_proto",
+    srcs = ["unlinked_client_account.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":event_group_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "unlinked_client_accounts_service_proto",
+    srcs = ["unlinked_client_accounts_service.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":unlinked_client_account_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
+)

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -48,7 +48,7 @@ message UnlinkedClientAccount {
       [(google.api.field_behavior) = REQUIRED];
 
   // The distinct brands observed for this client account. Display hint only.
-  repeated string brands = 3 [(google.api.field_behavior) = OPTIONAL];
+  repeated string brands = 3 [(google.api.field_behavior) = UNORDERED_LIST];
 
   // One EventGroup observed for this client account, for traceability.
   //
@@ -62,10 +62,10 @@ message UnlinkedClientAccount {
     string event_group_reference_id = 4;
 
     // Entity key of an observed EventGroup.
-    EventGroup.EntityKey entity_key = 6;
+    EventGroup.EntityKey entity_key = 5;
   }
 
   // The time this client account was first observed unlinked.
-  google.protobuf.Timestamp first_observed_time = 5
+  google.protobuf.Timestamp first_observed_time = 6
       [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -1,0 +1,71 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.api.v2alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/api/v2alpha/event_group.proto";
+
+option java_package = "org.wfanet.measurement.api.v2alpha";
+option java_multiple_files = true;
+option java_outer_classname = "UnlinkedClientAccountProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
+
+// An advertiser client-account reference ID that EventGroupSync could not
+// resolve to any MeasurementConsumer ("unlinked").
+message UnlinkedClientAccount {
+  option (google.api.resource) = {
+    type: "halo.wfanet.org/UnlinkedClientAccount"
+    pattern: "dataProviders/{data_provider}/unlinkedClientAccounts/{unlinked_client_account}"
+    singular: "unlinkedClientAccount"
+    plural: "unlinkedClientAccounts"
+  };
+
+  // Resource name.
+  //
+  // Ignored on the `ReplaceUnlinkedClientAccounts` write path: the
+  // request-level `parent` DataProvider and each entry
+  // `client_account_reference_id` are authoritative.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // Reference ID of the client account in the DataProvider ecosystem.
+  string client_account_reference_id = 2
+      [(google.api.field_behavior) = REQUIRED];
+
+  // The distinct brands observed for this client account. Display hint only.
+  repeated string brands = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // One EventGroup observed for this client account, for traceability.
+  //
+  // Selected deterministically across the EventGroups observed for this
+  // account: `entity_key` is preferred when any observed EventGroup carries
+  // one, falling back to `event_group_reference_id`. Among candidates of the
+  // chosen kind, the lexicographically smallest is used, so repeated syncs
+  // over the same input produce the same value.
+  oneof observed_event_group {
+    // Legacy EventGroup reference ID.
+    string event_group_reference_id = 4;
+
+    // Entity key of an observed EventGroup.
+    EventGroup.EntityKey entity_key = 6;
+  }
+
+  // The time this client account was first observed unlinked.
+  google.protobuf.Timestamp first_observed_time = 5
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
@@ -1,0 +1,66 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.api.v2alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "wfa/measurement/api/v2alpha/unlinked_client_account.proto";
+
+option java_package = "org.wfanet.measurement.api.v2alpha";
+option java_multiple_files = true;
+option java_outer_classname = "UnlinkedClientAccountsServiceProto";
+option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
+
+// Service for managing UnlinkedClientAccounts.
+service UnlinkedClientAccounts {
+  // Replaces the full set of UnlinkedClientAccounts for a single DataProvider.
+  //
+  // This reconciles the stored set against the incoming set: newly-unlinked
+  // accounts are inserted, still-unlinked accounts are kept (preserving their
+  // `first_observed_time`), and accounts absent from the incoming set are
+  // deleted.
+  //
+  // This is a full-set reconcile and is therefore idempotent: re-issuing the
+  // same request yields the same stored state.
+  rpc ReplaceUnlinkedClientAccounts(ReplaceUnlinkedClientAccountsRequest)
+      returns (ReplaceUnlinkedClientAccountsResponse) {}
+}
+
+// Request message for the `ReplaceUnlinkedClientAccounts` method.
+message ReplaceUnlinkedClientAccountsRequest {
+  // The parent DataProvider resource name.
+  // Format: `dataProviders/{data_provider}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "halo.wfanet.org/UnlinkedClientAccount"
+    }
+  ];
+
+  // The full current set of unlinked client accounts for the DataProvider.
+  //
+  // An empty set deletes all stored accounts for this DataProvider.
+  repeated UnlinkedClientAccount unlinked_client_accounts = 2
+      [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the `ReplaceUnlinkedClientAccounts` method.
+message ReplaceUnlinkedClientAccountsResponse {
+  // The reconciled set of unlinked client accounts, with `first_observed_time`
+  // populated.
+  repeated UnlinkedClientAccount unlinked_client_accounts = 1;
+}

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
@@ -53,7 +53,8 @@ message ReplaceUnlinkedClientAccountsRequest {
 
   // The full current set of unlinked client accounts for the DataProvider.
   //
-  // An empty set deletes all stored accounts for this DataProvider.
+  // An empty set deletes all stored accounts for this DataProvider. A maximum
+  // of 1000 `UnlinkedClientAccount`s can be replaced in a single call.
   repeated UnlinkedClientAccount unlinked_client_accounts = 2
       [(google.api.field_behavior) = OPTIONAL];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
@@ -46,9 +46,7 @@ message ReplaceUnlinkedClientAccountsRequest {
   // Format: `dataProviders/{data_provider}`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      child_type: "halo.wfanet.org/UnlinkedClientAccount"
-    }
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
   ];
 
   // The full current set of unlinked client accounts for the DataProvider.


### PR DESCRIPTION
Adds the v2alpha UnlinkedClientAccount resource and UnlinkedClientAccounts service with a ReplaceUnlinkedClientAccounts RPC. These surface advertiser client-account reference IDs that EventGroupSync could not resolve to a MeasurementConsumer, scoped to a DataProvider parent. Consumed by the Kingdom in cross-media-measurement.

Issue: #290
