### PR TITLE
feat: add AwsKmsParams.CredentialSource for direct Confidential Space AWS KMS auth

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -107,13 +107,15 @@ message FulfillRequisitionRequest {
         // AWS-specific parameters for KMS. Set when AWS KMS is used
         // for the KEK. If not set, GCP KMS is assumed.
         message AwsKmsParams {
-          // AWS IAM role ARN to assume via GCP identity federation.
+          // AWS IAM role ARN to assume.
           string role_arn = 1;
           // Identifier for the assumed AWS role session.
           string role_session = 2;
           // AWS region for STS and KMS endpoints.
           string region = 3;
-          // OIDC audience for the GCP ID token presented to AWS IAM.
+          // Audience presented to AWS STS when assuming `role_arn`: the GCP
+          // ID-token audience for `GCP_WORKLOAD_IDENTITY`, or the Confidential
+          // Space attestation-token audience for `CONFIDENTIAL_SPACE`.
           string audience = 4;
 
           // How the workload authenticates to AWS STS to assume `role_arn`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -56,13 +56,12 @@ message FulfillRequisitionRequest {
     // 1. The `data` in `measurement_spec` from the `Requisition`.
     // 2. The SHA256 hash of `encrypted_requisition_spec` from the
     //    `Requisition`.
-    bytes requisition_fingerprint = 2
-        [ (google.api.field_behavior) = REQUIRED ];
+    bytes requisition_fingerprint = 2 [(google.api.field_behavior) = REQUIRED];
 
     // The `nonce` value from the `encrypted_requisition_spec`.
     // (-- api-linter: core::0141::forbidden-types=disabled
     //     aip.dev/not-precedent: This is a random 64-bit value. --)
-    fixed64 nonce = 3 [ (google.api.field_behavior) = REQUIRED ];
+    fixed64 nonce = 3 [(google.api.field_behavior) = REQUIRED];
 
     // The protocol config of the Computation. This is used to validate that
     // EDPs and the MPC are using the same protocol config.
@@ -210,7 +209,7 @@ message FulfillRequisitionRequest {
     // operation, the operation will not occur and will result in an ABORTED
     // status.
     // TODO(@renjiezh): Make this REQUIRED once it has been adopted by all EDPs.
-    string etag = 7 [ (google.api.field_behavior) = OPTIONAL ];
+    string etag = 7 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // The chunk message for this streaming request.
@@ -234,7 +233,7 @@ message FulfillRequisitionRequest {
     // The optimal size of this field is one that would result in the
     // `FulfillRequisitionRequest` message being between 16KiB and 64KiB.
     // See https://github.com/grpc/grpc.github.io/issues/371
-    bytes data = 1 [ (google.api.field_behavior) = REQUIRED ];
+    bytes data = 1 [(google.api.field_behavior) = REQUIRED];
   }
 
   // Request message payload. Exactly one of these must be specified.
@@ -252,5 +251,5 @@ message FulfillRequisitionRequest {
 // Response message for `FulfillRequisition` method.
 message FulfillRequisitionResponse {
   // Resulting state of the `Requisition`.
-  Requisition.State state = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  Requisition.State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -56,12 +56,13 @@ message FulfillRequisitionRequest {
     // 1. The `data` in `measurement_spec` from the `Requisition`.
     // 2. The SHA256 hash of `encrypted_requisition_spec` from the
     //    `Requisition`.
-    bytes requisition_fingerprint = 2 [(google.api.field_behavior) = REQUIRED];
+    bytes requisition_fingerprint = 2
+        [ (google.api.field_behavior) = REQUIRED ];
 
     // The `nonce` value from the `encrypted_requisition_spec`.
     // (-- api-linter: core::0141::forbidden-types=disabled
     //     aip.dev/not-precedent: This is a random 64-bit value. --)
-    fixed64 nonce = 3 [(google.api.field_behavior) = REQUIRED];
+    fixed64 nonce = 3 [ (google.api.field_behavior) = REQUIRED ];
 
     // The protocol config of the Computation. This is used to validate that
     // EDPs and the MPC are using the same protocol config.
@@ -114,6 +115,23 @@ message FulfillRequisitionRequest {
           string region = 3;
           // OIDC audience for the GCP ID token presented to AWS IAM.
           string audience = 4;
+
+          // How the workload authenticates to AWS STS to assume `role_arn`.
+          enum CredentialSource {
+            // Unspecified; treated as `GCP_WORKLOAD_IDENTITY` for backward
+            // compatibility.
+            CREDENTIAL_SOURCE_UNSPECIFIED = 0;
+            // Two-hop: GCP Workload Identity Federation plus service-account
+            // impersonation mints the OIDC token presented to AWS STS. Requires
+            // `workload_identity_provider` and `impersonated_service_account`.
+            GCP_WORKLOAD_IDENTITY = 1;
+            // Direct: a Confidential Space attestation token is presented to
+            // AWS STS. Requires no GCP project; `workload_identity_provider`
+            // and `impersonated_service_account` are unused.
+            CONFIDENTIAL_SPACE = 2;
+          }
+          // How the workload authenticates to AWS to assume `role_arn`.
+          CredentialSource credential_source = 5;
         }
 
         // An [EncryptionKey] in an encrypted format, used as the Data
@@ -190,7 +208,7 @@ message FulfillRequisitionRequest {
     // operation, the operation will not occur and will result in an ABORTED
     // status.
     // TODO(@renjiezh): Make this REQUIRED once it has been adopted by all EDPs.
-    string etag = 7 [(google.api.field_behavior) = OPTIONAL];
+    string etag = 7 [ (google.api.field_behavior) = OPTIONAL ];
   }
 
   // The chunk message for this streaming request.
@@ -214,7 +232,7 @@ message FulfillRequisitionRequest {
     // The optimal size of this field is one that would result in the
     // `FulfillRequisitionRequest` message being between 16KiB and 64KiB.
     // See https://github.com/grpc/grpc.github.io/issues/371
-    bytes data = 1 [(google.api.field_behavior) = REQUIRED];
+    bytes data = 1 [ (google.api.field_behavior) = REQUIRED ];
   }
 
   // Request message payload. Exactly one of these must be specified.
@@ -232,5 +250,5 @@ message FulfillRequisitionRequest {
 // Response message for `FulfillRequisition` method.
 message FulfillRequisitionResponse {
   // Resulting state of the `Requisition`.
-  Requisition.State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  Requisition.State state = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }


### PR DESCRIPTION
Adds a `credential_source` field (`CredentialSource` enum) to the TrusTee `AwsKmsParams` in `FulfillRequisitionRequest` so a requisition can declare whether the workload assumes the AWS role via GCP Workload Identity (two-hop) or directly from a Confidential Space attestation. The change is backward-compatible: `CREDENTIAL_SOURCE_UNSPECIFIED` defaults to `GCP_WORKLOAD_IDENTITY`, so existing AWS-KMS EDPs are unaffected.