### PR TITLE
refactor: redesign UnlinkedClientAccount to use standard methods

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -779,6 +779,7 @@ proto_library(
     srcs = ["unlinked_client_account.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":event_group_metadata_proto",
         ":event_group_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
@@ -792,7 +793,9 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":unlinked_client_account_proto",
+        "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:empty_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -779,10 +779,10 @@ proto_library(
     srcs = ["unlinked_client_account.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
-        ":event_group_metadata_proto",
         ":event_group_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/client_account.proto
@@ -69,5 +69,9 @@ message ClientAccount {
   // The combination of `data_provider` and `client_account_reference_id` must
   // be unique. Each reference ID maps to exactly one `MeasurementConsumer` per
   // `DataProvider`, or (`MeasurementConsumer`, `DataProvider`) pair.
+  //
+  // A given (`DataProvider`, `client_account_reference_id`) cannot have both a
+  // `ClientAccount` and an `UnlinkedClientAccount`; creating a `ClientAccount`
+  // deletes any corresponding `UnlinkedClientAccount`.
   string client_account_reference_id = 3;
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/client_accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/client_accounts_service.proto
@@ -30,12 +30,20 @@ option go_package = "github.com/world-federation-of-advertisers/cross-media-meas
 // Service for interacting with `ClientAccount` resources.
 service ClientAccounts {
   // Creates a new `ClientAccount`.
+  //
+  // If an `UnlinkedClientAccount` exists for the same `DataProvider` and
+  // `client_account_reference_id`, it is atomically deleted, since an account
+  // cannot be both linked and unlinked.
   rpc CreateClientAccount(CreateClientAccountRequest) returns (ClientAccount) {
     option (google.api.method_signature) = "parent,client_account";
   }
 
   // Batch creates `ClientAccount`s. Results in an error if any of the
   // specified `ClientAccount`s fail to be created.
+  //
+  // As with `CreateClientAccount`, any `UnlinkedClientAccount` matching a
+  // created `ClientAccount`'s `DataProvider` and `client_account_reference_id`
+  // is atomically deleted.
   rpc BatchCreateClientAccounts(BatchCreateClientAccountsRequest)
       returns (BatchCreateClientAccountsResponse) {}
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -47,6 +47,9 @@ message UnlinkedClientAccount {
   // The combination of the parent `DataProvider` and
   // `client_account_reference_id` must be unique and cannot be shared by both a
   // `ClientAccount` and an `UnlinkedClientAccount`.
+  //
+  // Used as the resource ID, so this must be a URL-safe string, such that
+  // URL-encoding or -decoding results in the same string.
   string client_account_reference_id = 2
       [(google.api.field_behavior) = REQUIRED];
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -27,14 +27,9 @@ option java_multiple_files = true;
 option java_outer_classname = "UnlinkedClientAccountProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
-// A client account observed within a `DataProvider`'s ecosystem that could not
-// be resolved to any `MeasurementConsumer` ("unlinked").
-//
-// This is effectively a `ClientAccount` that has not yet been mapped to a
-// `MeasurementConsumer`. A given (`DataProvider`,
-// `client_account_reference_id`) can have either a `ClientAccount` or an
-// `UnlinkedClientAccount`, but not both: creating the corresponding
-// `ClientAccount` deletes the `UnlinkedClientAccount`.
+// A `ClientAccount` observed by EventGroupSync that could not be resolved to a
+// `MeasurementConsumer` ("unlinked"). It is effectively a `ClientAccount` that
+// is not yet mapped to a `MeasurementConsumer`.
 message UnlinkedClientAccount {
   option (google.api.resource) = {
     type: "halo.wfanet.org/UnlinkedClientAccount"

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -18,9 +18,9 @@ package wfa.measurement.api.v2alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "wfa/measurement/api/v2alpha/event_group.proto";
-import "wfa/measurement/api/v2alpha/event_group_metadata.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -53,20 +53,21 @@ message UnlinkedClientAccount {
   string client_account_reference_id = 2
       [(google.api.field_behavior) = REQUIRED];
 
-  // Metadata of one campaign observed for this client account.
-  //
-  // Provides a human-readable hint (e.g. `brand_name`) for display, since the
-  // account is otherwise only identified by `client_account_reference_id`.
-  EventGroupMetadata.AdMetadata.CampaignMetadata campaign_metadata = 3;
+  // Entity metadata denormalized from the observed EventGroup, for display.
+  // Same schema as `EventGroupMetadata.entity_metadata` (e.g. a `brand_name`
+  // entry).
+  google.protobuf.Struct entity_metadata = 3;
 
-  // One EventGroup observed for this client account, for traceability.
+  // Identifiers of one EventGroup observed for this account, for traceability.
+  // The EventGroup exists in the DataProvider's system but is not registered
+  // in the Kingdom: EventGroupSync only registers an EventGroup for an account
+  // that resolves to a MeasurementConsumer, and this one is unlinked, so no
+  // CMMS EventGroup is created. It is therefore referenced by these
+  // DataProvider-side identifiers rather than a resource name.
   //
-  // Corresponds to `EventGroup.event_group_reference_id` and
-  // `EventGroup.entity_key`. Selected deterministically across the EventGroups
-  // observed for this account: `entity_key` is preferred when any observed
-  // EventGroup carries one, falling back to `event_group_reference_id`. Among
-  // candidates of the chosen kind, the lexicographically smallest is used, so
-  // repeated syncs over the same input produce the same value.
+  // Chosen deterministically so repeated syncs yield the same value:
+  // `entity_key` is preferred over `event_group_reference_id`, and the
+  // lexicographically smallest candidate wins.
   oneof observed_event_group {
     // Legacy EventGroup reference ID. See
     // `EventGroup.event_group_reference_id`.

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -20,14 +20,21 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
 import "wfa/measurement/api/v2alpha/event_group.proto";
+import "wfa/measurement/api/v2alpha/event_group_metadata.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "UnlinkedClientAccountProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
-// An advertiser client-account reference ID that EventGroupSync could not
-// resolve to any MeasurementConsumer ("unlinked").
+// A client account observed within a `DataProvider`'s ecosystem that could not
+// be resolved to any `MeasurementConsumer` ("unlinked").
+//
+// This is effectively a `ClientAccount` that has not yet been mapped to a
+// `MeasurementConsumer`. A given (`DataProvider`,
+// `client_account_reference_id`) can have either a `ClientAccount` or an
+// `UnlinkedClientAccount`, but not both: creating the corresponding
+// `ClientAccount` deletes the `UnlinkedClientAccount`.
 message UnlinkedClientAccount {
   option (google.api.resource) = {
     type: "halo.wfanet.org/UnlinkedClientAccount"
@@ -37,35 +44,43 @@ message UnlinkedClientAccount {
   };
 
   // Resource name.
-  //
-  // Ignored on the `ReplaceUnlinkedClientAccounts` write path: the
-  // request-level `parent` DataProvider and each entry
-  // `client_account_reference_id` are authoritative.
   string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-  // Reference ID of the client account in the DataProvider ecosystem.
+  // Reference ID for the account in the `DataProvider`'s ecosystem.
+  // Must not exceed 36 characters.
+  //
+  // This is the same identifier as `ClientAccount.client_account_reference_id`.
+  // The combination of the parent `DataProvider` and
+  // `client_account_reference_id` must be unique and cannot be shared by both a
+  // `ClientAccount` and an `UnlinkedClientAccount`.
   string client_account_reference_id = 2
       [(google.api.field_behavior) = REQUIRED];
 
-  // The distinct brands observed for this client account. Display hint only.
-  repeated string brands = 3 [(google.api.field_behavior) = UNORDERED_LIST];
+  // Metadata of one campaign observed for this client account.
+  //
+  // Provides a human-readable hint (e.g. `brand_name`) for display, since the
+  // account is otherwise only identified by `client_account_reference_id`.
+  EventGroupMetadata.AdMetadata.CampaignMetadata campaign_metadata = 3;
 
   // One EventGroup observed for this client account, for traceability.
   //
-  // Selected deterministically across the EventGroups observed for this
-  // account: `entity_key` is preferred when any observed EventGroup carries
-  // one, falling back to `event_group_reference_id`. Among candidates of the
-  // chosen kind, the lexicographically smallest is used, so repeated syncs
-  // over the same input produce the same value.
+  // Corresponds to `EventGroup.event_group_reference_id` and
+  // `EventGroup.entity_key`. Selected deterministically across the EventGroups
+  // observed for this account: `entity_key` is preferred when any observed
+  // EventGroup carries one, falling back to `event_group_reference_id`. Among
+  // candidates of the chosen kind, the lexicographically smallest is used, so
+  // repeated syncs over the same input produce the same value.
   oneof observed_event_group {
-    // Legacy EventGroup reference ID.
+    // Legacy EventGroup reference ID. See
+    // `EventGroup.event_group_reference_id`.
     string event_group_reference_id = 4;
 
-    // Entity key of an observed EventGroup.
+    // Entity key of an observed EventGroup. See `EventGroup.entity_key`.
     EventGroup.EntityKey entity_key = 5;
   }
 
-  // The time this client account was first observed unlinked.
-  google.protobuf.Timestamp first_observed_time = 6
+  // The time this `UnlinkedClientAccount` was created, i.e. when the account
+  // was first observed unlinked.
+  google.protobuf.Timestamp create_time = 6
       [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -27,8 +27,8 @@ option java_multiple_files = true;
 option java_outer_classname = "UnlinkedClientAccountProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
-// A `ClientAccount` observed by EventGroupSync that is not yet mapped to a
-// `MeasurementConsumer` ("unlinked").
+// A `ClientAccount` that is not yet mapped to a `MeasurementConsumer`
+// ("unlinked").
 message UnlinkedClientAccount {
   option (google.api.resource) = {
     type: "halo.wfanet.org/UnlinkedClientAccount"
@@ -53,27 +53,25 @@ message UnlinkedClientAccount {
   string client_account_reference_id = 2
       [(google.api.field_behavior) = REQUIRED];
 
-  // Entity metadata denormalized from the observed EventGroup, for display.
-  // Same schema as `EventGroupMetadata.entity_metadata` (e.g. a `brand_name`
-  // entry).
+  // Metadata for the DataProvider-side entity this client account is associated
+  // with, using the same schema as `EventGroupMetadata.entity_metadata` (e.g. a
+  // `brand_name` entry).
   google.protobuf.Struct entity_metadata = 3;
 
-  // Identifiers of one EventGroup observed for this account, for traceability.
-  // The EventGroup exists in the DataProvider's system but is not registered
-  // in the Kingdom: EventGroupSync only registers an EventGroup for an account
-  // that resolves to a MeasurementConsumer, and this one is unlinked, so no
-  // CMMS EventGroup is created. It is therefore referenced by these
-  // DataProvider-side identifiers rather than a resource name.
+  // Identifiers of the DataProvider-side entity this client account is
+  // associated with, for traceability.
   //
-  // Chosen deterministically so repeated syncs yield the same value:
-  // `entity_key` is preferred over `event_group_reference_id`, and the
-  // lexicographically smallest candidate wins.
+  // This entity maps to an `EventGroup`, but the corresponding `EventGroup`
+  // resource may not exist. It is therefore referenced by these
+  // DataProvider-side identifiers (the same ones an `EventGroup` carries)
+  // rather than by resource name. At most one is set; `entity_key` is preferred
+  // over the legacy `event_group_reference_id`.
   oneof observed_event_group {
-    // Legacy EventGroup reference ID. See
+    // Legacy DataProvider-side reference ID. See
     // `EventGroup.event_group_reference_id`.
     string event_group_reference_id = 4;
 
-    // Entity key of an observed EventGroup. See `EventGroup.entity_key`.
+    // Entity key of the DataProvider-side entity. See `EventGroup.entity_key`.
     EventGroup.EntityKey entity_key = 5;
   }
 

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_account.proto
@@ -27,9 +27,8 @@ option java_multiple_files = true;
 option java_outer_classname = "UnlinkedClientAccountProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
-// A `ClientAccount` observed by EventGroupSync that could not be resolved to a
-// `MeasurementConsumer` ("unlinked"). It is effectively a `ClientAccount` that
-// is not yet mapped to a `MeasurementConsumer`.
+// A `ClientAccount` observed by EventGroupSync that is not yet mapped to a
+// `MeasurementConsumer` ("unlinked").
 message UnlinkedClientAccount {
   option (google.api.resource) = {
     type: "halo.wfanet.org/UnlinkedClientAccount"

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
@@ -16,8 +16,10 @@ syntax = "proto3";
 
 package wfa.measurement.api.v2alpha;
 
+import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/empty.proto";
 import "wfa/measurement/api/v2alpha/unlinked_client_account.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
@@ -25,41 +27,145 @@ option java_multiple_files = true;
 option java_outer_classname = "UnlinkedClientAccountsServiceProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/cmms/apiv2alpha/cmmspb";
 
-// Service for managing UnlinkedClientAccounts.
+// Service for interacting with `UnlinkedClientAccount` resources.
 service UnlinkedClientAccounts {
-  // Replaces the full set of UnlinkedClientAccounts for a single DataProvider.
-  //
-  // This reconciles the stored set against the incoming set: newly-unlinked
-  // accounts are inserted, still-unlinked accounts are kept (preserving their
-  // `first_observed_time`), and accounts absent from the incoming set are
-  // deleted.
-  //
-  // This is a full-set reconcile and is therefore idempotent: re-issuing the
-  // same request yields the same stored state.
-  rpc ReplaceUnlinkedClientAccounts(ReplaceUnlinkedClientAccountsRequest)
-      returns (ReplaceUnlinkedClientAccountsResponse) {}
+  // Creates a new `UnlinkedClientAccount`.
+  rpc CreateUnlinkedClientAccount(CreateUnlinkedClientAccountRequest)
+      returns (UnlinkedClientAccount) {
+    option (google.api.method_signature) = "parent,unlinked_client_account";
+  }
+
+  // Batch creates `UnlinkedClientAccount`s. Results in an error if any of the
+  // specified `UnlinkedClientAccount`s fail to be created.
+  rpc BatchCreateUnlinkedClientAccounts(
+      BatchCreateUnlinkedClientAccountsRequest)
+      returns (BatchCreateUnlinkedClientAccountsResponse) {}
+
+  // Returns the `UnlinkedClientAccount` with the specified resource name.
+  rpc GetUnlinkedClientAccount(GetUnlinkedClientAccountRequest)
+      returns (UnlinkedClientAccount) {
+    option (google.api.method_signature) = "name";
+  }
+
+  // Lists `UnlinkedClientAccount`s for a parent `DataProvider`.
+  rpc ListUnlinkedClientAccounts(ListUnlinkedClientAccountsRequest)
+      returns (ListUnlinkedClientAccountsResponse) {
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Deletes an existing `UnlinkedClientAccount`.
+  rpc DeleteUnlinkedClientAccount(DeleteUnlinkedClientAccountRequest)
+      returns (google.protobuf.Empty) {
+    option (google.api.method_signature) = "name";
+  }
+
+  // Batch deletes `UnlinkedClientAccount`s. Results in an error if any of the
+  // specified `UnlinkedClientAccount`s fail to be deleted.
+  rpc BatchDeleteUnlinkedClientAccounts(
+      BatchDeleteUnlinkedClientAccountsRequest)
+      returns (google.protobuf.Empty) {}
 }
 
-// Request message for the `ReplaceUnlinkedClientAccounts` method.
-message ReplaceUnlinkedClientAccountsRequest {
-  // The parent DataProvider resource name.
-  // Format: `dataProviders/{data_provider}`
+// Request message for `CreateUnlinkedClientAccount` method.
+message CreateUnlinkedClientAccountRequest {
+  // Resource name of the parent `DataProvider`.
   string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = REQUIRED
   ];
 
-  // The full current set of unlinked client accounts for the DataProvider.
+  // The `UnlinkedClientAccount` to create.
   //
-  // An empty set deletes all stored accounts for this DataProvider. A maximum
-  // of 1000 `UnlinkedClientAccount`s can be replaced in a single call.
-  repeated UnlinkedClientAccount unlinked_client_accounts = 2
-      [(google.api.field_behavior) = OPTIONAL];
+  // The `name` field will be ignored, and the system will assign an ID.
+  UnlinkedClientAccount unlinked_client_account = 2
+      [(google.api.field_behavior) = REQUIRED];
 }
 
-// Response message for the `ReplaceUnlinkedClientAccounts` method.
-message ReplaceUnlinkedClientAccountsResponse {
-  // The reconciled set of unlinked client accounts, with `first_observed_time`
-  // populated.
+// Request message for `BatchCreateUnlinkedClientAccounts` method.
+message BatchCreateUnlinkedClientAccountsRequest {
+  // Resource name of the parent `DataProvider`.
+  string parent = 1 [
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // The requests specifying the `UnlinkedClientAccount`s to create. Either all
+  // requests must have the same parent and the parent must match the top-level
+  // parent, or all requests must leave the parent unset. A maximum of 1000
+  // `UnlinkedClientAccount`s can be created in a single batch.
+  repeated CreateUnlinkedClientAccountRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for `BatchCreateUnlinkedClientAccounts` method.
+message BatchCreateUnlinkedClientAccountsResponse {
+  // The `UnlinkedClientAccount` resources.
   repeated UnlinkedClientAccount unlinked_client_accounts = 1;
+}
+
+// Request message for `GetUnlinkedClientAccount` method.
+message GetUnlinkedClientAccountRequest {
+  // Resource name of the `UnlinkedClientAccount` to retrieve.
+  string name = 1 [
+    (google.api.resource_reference).type =
+        "halo.wfanet.org/UnlinkedClientAccount",
+    (google.api.field_behavior) = REQUIRED
+  ];
+}
+
+// Request message for `ListUnlinkedClientAccounts` method.
+message ListUnlinkedClientAccountsRequest {
+  // Resource name of the parent `DataProvider`.
+  string parent = 1 [
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // The maximum number of resources to return. The service may return fewer
+  // than this value.
+  //
+  // If unspecified, at most 50 resources will be returned. The maximum value
+  // is 1000; values above this will be coerced to the maximum.
+  int32 page_size = 2;
+
+  // A token from a previous call, specified to retrieve the next page. See
+  // https://aip.dev/158.
+  string page_token = 3;
+}
+
+// Response message for `ListUnlinkedClientAccounts` method.
+message ListUnlinkedClientAccountsResponse {
+  // The `UnlinkedClientAccount` resources.
+  repeated UnlinkedClientAccount unlinked_client_accounts = 1;
+
+  // A token that can be specified in a subsequent call to retrieve the next
+  // page. See https://aip.dev/158.
+  string next_page_token = 2;
+}
+
+// Request message for `DeleteUnlinkedClientAccount` method.
+message DeleteUnlinkedClientAccountRequest {
+  // Resource name of the `UnlinkedClientAccount` to delete.
+  string name = 1 [
+    (google.api.resource_reference).type =
+        "halo.wfanet.org/UnlinkedClientAccount",
+    (google.api.field_behavior) = REQUIRED
+  ];
+}
+
+// Request message for `BatchDeleteUnlinkedClientAccounts` method.
+message BatchDeleteUnlinkedClientAccountsRequest {
+  // Resource name of the parent `DataProvider`.
+  string parent = 1 [
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // The resource names of the `UnlinkedClientAccount`s to delete. A maximum of
+  // 1000 `UnlinkedClientAccount`s can be deleted in a single batch.
+  repeated string names = 2 [
+    (google.api.resource_reference).type =
+        "halo.wfanet.org/UnlinkedClientAccount",
+    (google.api.field_behavior) = REQUIRED
+  ];
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/unlinked_client_accounts_service.proto
@@ -76,7 +76,9 @@ message CreateUnlinkedClientAccountRequest {
 
   // The `UnlinkedClientAccount` to create.
   //
-  // The `name` field will be ignored, and the system will assign an ID.
+  // The `name` field will be ignored. The resource ID is the
+  // `client_account_reference_id`, so the resource name is
+  // `{parent}/unlinkedClientAccounts/{client_account_reference_id}`.
   UnlinkedClientAccount unlinked_client_account = 2
       [(google.api.field_behavior) = REQUIRED];
 }


### PR DESCRIPTION
Replace the custom ReplaceUnlinkedClientAccounts RPC with standard Create,
BatchCreate, Get, List, Delete, and BatchDelete methods. Carry the observed
EventGroup campaign metadata (brand_name) and a standard OUTPUT_ONLY
create_time in place of first_observed_time, and document that
CreateClientAccount deletes the corresponding UnlinkedClientAccount. Addresses
post-merge review on #289.

Issue: #290
