### PR TITLE
Replace AwsKmsParams.credential_source with a token_audience oneof

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -112,27 +112,26 @@ message FulfillRequisitionRequest {
           string role_session = 2;
           // AWS region for STS and KMS endpoints.
           string region = 3;
-          // Audience presented to AWS STS when assuming `role_arn`: the GCP
-          // ID-token audience for `GCP_WORKLOAD_IDENTITY`, or the Confidential
-          // Space attestation-token audience for `CONFIDENTIAL_SPACE`.
-          string audience = 4;
 
-          // How the workload authenticates to AWS STS to assume `role_arn`.
-          enum CredentialSource {
-            // Unspecified; treated as `GCP_WORKLOAD_IDENTITY` for backward
-            // compatibility.
-            CREDENTIAL_SOURCE_UNSPECIFIED = 0;
-            // Two-hop: GCP Workload Identity Federation plus service-account
-            // impersonation mints the OIDC token presented to AWS STS. Requires
-            // `workload_identity_provider` and `impersonated_service_account`.
-            GCP_WORKLOAD_IDENTITY = 1;
-            // Direct: a Confidential Space attestation token is presented to
-            // AWS STS. Requires no GCP project; `workload_identity_provider`
-            // and `impersonated_service_account` are unused.
-            CONFIDENTIAL_SPACE = 2;
+          // Field 5 held a `credential_source` enum that the `token_audience`
+          // oneof replaces. It was released with a different wire type, so the
+          // field number is not reused.
+          reserved 5;
+
+          // Audience presented to AWS STS when assuming `role_arn`. The member
+          // that is set determines how the workload authenticates to AWS STS.
+          oneof token_audience {
+            // Audience of the OIDC ID token minted via GCP Workload Identity
+            // Federation and service-account impersonation, then presented to
+            // AWS STS. Also requires `workload_identity_provider` and
+            // `impersonated_service_account`.
+            string workload_identity_id_token_audience = 4;
+            // Audience of the Confidential Space attestation token, presented
+            // directly to AWS STS. Requires no GCP project;
+            // `workload_identity_provider` and `impersonated_service_account`
+            // are unused.
+            string confidential_space_attestation_token_audience = 6;
           }
-          // How the workload authenticates to AWS to assume `role_arn`.
-          CredentialSource credential_source = 5;
         }
 
         // An [EncryptionKey] in an encrypted format, used as the Data

--- a/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -106,17 +106,14 @@ message FulfillRequisitionRequest {
         // AWS-specific parameters for KMS. Set when AWS KMS is used
         // for the KEK. If not set, GCP KMS is assumed.
         message AwsKmsParams {
+          reserved 5;
+
           // AWS IAM role ARN to assume.
           string role_arn = 1;
           // Identifier for the assumed AWS role session.
           string role_session = 2;
           // AWS region for STS and KMS endpoints.
           string region = 3;
-
-          // Field 5 held a `credential_source` enum that the `token_audience`
-          // oneof replaces. It was released with a different wire type, so the
-          // field number is not reused.
-          reserved 5;
 
           // Audience presented to AWS STS when assuming `role_arn`. The member
           // that is set determines how the workload authenticates to AWS STS.


### PR DESCRIPTION
The credential source was redundant with the audience field, whose meaning it selected, and it relied on the unspecified enum value meaning GCP_WORKLOAD_IDENTITY. Modelling the two audiences as a oneof makes the credential source implicit in which member is set, so an inconsistent combination is unrepresentable and no zero value has to be reinterpreted.

Existing writers keep field 4, so their messages still read as the workload-identity variant. The Confidential Space audience takes field 6 rather than 5 because field 5 was released as the enum and has a different wire type.

Issue: https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/4309