### PR TITLE
feat!: Drop DeterministicTruncatedLaplaceNoiseParams

### DIFF
--- a/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/protocol_config.proto
@@ -277,16 +277,6 @@ message ProtocolConfig {
 
     // Optional minimum thresholds for releasing the result.
     ResultMinimumThresholds result_minimum_thresholds = 2;
-
-    // Required when `noise_mechanism` is DETERMINISTIC_TRUNCATED_LAPLACE.
-    DeterministicTruncatedLaplaceNoiseParams
-        deterministic_truncated_laplace_noise_params = 3;
-  }
-
-  // Parameters for DETERMINISTIC_TRUNCATED_LAPLACE noise.
-  message DeterministicTruncatedLaplaceNoiseParams {
-    // Draws are truncated to `[-truncation_bound, truncation_bound]`.
-    int32 truncation_bound = 1;
   }
 
   // Configuration for a specific protocol.


### PR DESCRIPTION
Removes `ProtocolConfig.TrusTee.deterministic_truncated_laplace_noise_params` and the `DeterministicTruncatedLaplaceNoiseParams` message it carried, and reserves field number 3.

**Nothing produces or consumes it.** The Kingdom's `toProtocolConfig` stamps only `noise_mechanism` and `result_minimum_thresholds`, so the field has been absent from every `Measurement` since the mechanism went live. `cross-media-measurement` has no reference to it outside generated code.

**There is nothing left for it to carry.** world-federation-of-advertisers/cross-media-measurement#4333 compiled the deterministic truncated-Laplace privacy parameters into the attested images that draw the noise, and the truncation bound is derived from them by `DeterministicTruncatedLaplaceParams.truncationBound`. The TrusTEE image, the EDP Aggregator and the reporting server all take it from that single source rather than from the wire, so that the reported variance cannot describe noise other than what was drawn.

**Its documentation is misleading.** The comment described the field as required when `noise_mechanism` is `DETERMINISTIC_TRUNCATED_LAPLACE`. That has never been true of any `Measurement` the Kingdom produces, so the API currently documents a contract the system does not implement.

Breaking in the sense that a field is removed, though `v2alpha` and unset in practice. Field number 3 is not reserved: only the Kingdom stamps `ProtocolConfig` and it never set the field, so no serialized `Measurement` carries it and the number can be reused safely.
